### PR TITLE
chore: 액션을 통해 PR의 코멘트에 따른 Pn룰 라벨링 자동화

### DIFF
--- a/.github/workflows/pnrule-auto-labeling.yml
+++ b/.github/workflows/pnrule-auto-labeling.yml
@@ -1,0 +1,40 @@
+name: Label PR Based on Comments
+
+on:
+  issue_comment:
+    types: [created, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+
+jobs:
+  label-pr:
+    name: PR Comment Label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add labels based on comment
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.ACTIONS_TOKEN }}
+          script: |
+            const comment = context.payload.comment.body;
+            const issueNumber = context.payload.issue?.number || context.payload.pull_request.number;
+            const repo = context.repo;
+
+            // 찾을 키워드 목록
+            const keywords = ["p1", "p2", "p3"];
+            let labelsToAdd = [];
+
+            keywords.forEach(keyword => {
+              if (comment.includes(keyword)) {
+                labelsToAdd.push(keyword);
+              }
+            });
+
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: repo.owner,
+                repo: repo.repo,
+                issue_number: issueNumber,
+                labels: labelsToAdd
+              });
+            }


### PR DESCRIPTION
<!-- 작성 예시 -->

<!-- # 문제 및 해결방안 -->
<!-- - 간략한 문제 설명 (문제 관련 링크 등등) -->
<!-- - 해당 문제를 해결한 방법에 대한 설명 -->

<!-- # 구현 설명 -->
<!-- - 동작 방식 등 코드적으로 구현한 방법에 대한 설명 -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 문제 및 해결방안

- 은식님께서 제안한 PR 코멘트 Pn Rule을 라벨링을 통해 효과적으로 보이면 어떨까 고민하다 GitHub Action을 통해 Auto Labeling을 구현하였습니다.

## ✍️ 구현 설명

- PR에 달린 Comment를 보고 `p1`, `p2`, `p3` 키워드가 존재하는지 파악 후, 존재한다면 라벨링을 하도록 구현하였습니다.

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

- 코멘트 수정에 대해서는 수정 이전 코멘트에 대한 정보를 제공하지 않기 떄문에 외부 DB를 붙이는 방법을 사용해야해서 삭제 및 수정에 대한 대응은 진행하지 않았습니다.

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
