### PR TITLE
fix: 주소 검색시 dimmed 처리된 overlay 위치가 잘못 배정되는 현상 수정

### DIFF
--- a/apps/web/src/components/search-place-bottom-sheet/style.css.ts
+++ b/apps/web/src/components/search-place-bottom-sheet/style.css.ts
@@ -6,7 +6,6 @@ import { recipe } from "@vanilla-extract/recipes";
 export const backgroundDimmed = style({
   position: "fixed",
   top: 0,
-  left: 0,
   width: "100%",
   maxWidth: "600px",
   height: "100dvh",


### PR DESCRIPTION
<!-- 작성 예시 -->

<!-- # 문제 및 해결방안 -->
<!-- - 간략한 문제 설명 (문제 관련 링크 등등) -->
<!-- - 해당 문제를 해결한 방법에 대한 설명 -->

<!-- # 구현 설명 -->
<!-- - 동작 방식 등 코드적으로 구현한 방법에 대한 설명 -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 문제 및 해결방안

- 주소 검색시 바텀시트 뒤의 Overlay의 위치가 잘못 배정되는 현상을 수정하였습니다.

## ✍️ 구현 설명

-

### 📷 이미지 첨부 (Option)

- 수정 전
![스크린샷 2025-03-19 오전 12 18 03](https://github.com/user-attachments/assets/07029f76-db40-42b9-a856-a91dd0c3b0e4)

- 수정 후
![스크린샷 2025-03-19 오전 12 18 16](https://github.com/user-attachments/assets/350a8ac1-1487-4ed8-8f10-b4c031ea637f)

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
