### PR TITLE
feat: 출발지 설정 API 연결 및 누락된 use client 추가

### DIFF
--- a/apps/web/app/api/locations/route.ts
+++ b/apps/web/app/api/locations/route.ts
@@ -1,0 +1,16 @@
+import {
+  LocationsResponse,
+  LocationsRequestProps,
+} from "@/api/types/locations/index.types";
+import { postRequest } from "@repo/shared/axios";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const data = await postRequest<LocationsResponse, LocationsRequestProps>({
+    url: `${process.env.NEXT_PUBLIC_BASE_URL}/locations`,
+    data: body,
+  });
+
+  return NextResponse.json(data);
+}

--- a/apps/web/src/api/types/locations/index.types.ts
+++ b/apps/web/src/api/types/locations/index.types.ts
@@ -1,0 +1,16 @@
+import { ICommon } from "../common/common.type";
+
+export interface LocationsRequestProps {
+  roomId: string;
+  memberId: string;
+  latitude: number;
+  longitude: number;
+}
+
+export interface Locations {
+  roomId: string;
+  latitude: number;
+  longitude: number;
+}
+
+export type LocationsResponse = ICommon<Locations>;

--- a/apps/web/src/components/create-room/organisms/select-start-place/SelectStartPlace.tsx
+++ b/apps/web/src/components/create-room/organisms/select-start-place/SelectStartPlace.tsx
@@ -1,23 +1,17 @@
 import SearchPlaceBottomSheet from "@/components/search-place-bottom-sheet";
 import { NaverMap } from "@repo/naver-map";
 
-interface ISelectStartPlace {
+interface SelectStartPlaceProps {
   roomId: string;
   memberId: string;
   memberImgUrl: string;
-  memberNickname: string;
 }
 
-const SelectStartPlace = ({
-  roomId,
-  memberId,
-  memberImgUrl,
-  memberNickname,
-}: ISelectStartPlace) => {
+const SelectStartPlace = (props: SelectStartPlaceProps) => {
   return (
     <>
       <NaverMap width="100vw" height="100vh" />
-      <SearchPlaceBottomSheet />
+      <SearchPlaceBottomSheet {...props} />
     </>
   );
 };

--- a/apps/web/src/components/create-room/templates/CreateRoomLayout.tsx
+++ b/apps/web/src/components/create-room/templates/CreateRoomLayout.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type {
   ICreateRoomValues,
   IRaondomProfile,
@@ -93,7 +95,6 @@ const CreateRoomLayout = ({
           roomId={data.data.id}
           memberId={data.data.member.id}
           memberImgUrl={data.data.member.profile}
-          memberNickname={data.data.member.nickname}
         />
       )}
     </div>

--- a/apps/web/src/components/search-place-bottom-sheet/index.tsx
+++ b/apps/web/src/components/search-place-bottom-sheet/index.tsx
@@ -12,8 +12,22 @@ import { getLatLng, Marker, NaverLatLng, useNaverMap } from "@repo/naver-map";
 import { convertWGS84ToLatLng, getFullAddressAndTitle } from "@/utils/location";
 import { useCurrentLocation } from "@/hooks/api/useCurrentLocation";
 import ProfileMarker from "./profile-marker";
+import { useSelectStartPlace } from "@/hooks/api/useSelectStartPlace";
+import { useRouter } from "next/navigation";
 
-const SearchPlaceBottomSheet = () => {
+interface SearchPlaceBottomSheetProps {
+  roomId: string;
+  memberId: string;
+  memberImgUrl: string;
+}
+
+const SearchPlaceBottomSheet = ({
+  roomId,
+  memberId,
+  memberImgUrl,
+}: SearchPlaceBottomSheetProps) => {
+  const router = useRouter();
+  const { mutate, isSuccess } = useSelectStartPlace();
   const [isSearching, setIsSearching] = useState<boolean>(false);
   const [place, setPlace] = useState<Place | null>(null);
 
@@ -28,7 +42,7 @@ const SearchPlaceBottomSheet = () => {
   const marker = Marker({
     map: map!,
     customMarkerData: {
-      marker: ProfileMarker({ profileImageUrl: "/images/create-room/2.png" }),
+      marker: ProfileMarker({ profileImageUrl: memberImgUrl }),
       width: 48,
       height: 48,
     },
@@ -77,7 +91,12 @@ const SearchPlaceBottomSheet = () => {
   const onClickSelectPlace = () => {
     if (!place) return;
 
-    // TODO: 생성된 모임방 uuid를 통해 모임장 위치 등록 API 요청 및 링크 생성 페이지로 라우팅
+    mutate({
+      roomId,
+      memberId,
+      latitude: Number(place.mapy),
+      longitude: Number(place.mapx),
+    });
   };
 
   const onClickRemovePlace = () => {
@@ -113,6 +132,12 @@ const SearchPlaceBottomSheet = () => {
 
     moveTo(latLng);
   }, [place, moveTo, marker]);
+
+  useEffect(() => {
+    if (!isSuccess) return;
+
+    router.push("/share");
+  }, [router, isSuccess]);
 
   return (
     <>
@@ -202,6 +227,7 @@ const SearchPlaceBottomSheet = () => {
               </button>
             </Flex>
 
+            {/* TODO: isSuccess를 활용해 API 요청중 버튼 disable */}
             <Button onClick={onClickSelectPlace}>
               <Text variant="title3">출발지로 설정하기</Text>
             </Button>

--- a/apps/web/src/hooks/api/useSelectStartPlace.ts
+++ b/apps/web/src/hooks/api/useSelectStartPlace.ts
@@ -1,0 +1,19 @@
+import { LocationsRequestProps } from "@/api/types/locations/index.types";
+import { useMutation } from "@repo/shared/tanstack-query";
+
+const selectStartPlace = async (requestBody: LocationsRequestProps) => {
+  const response = await fetch("/api/locations", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(requestBody),
+  });
+  return response.json();
+};
+
+export const useSelectStartPlace = () => {
+  return useMutation({
+    mutationFn: selectStartPlace,
+  });
+};


### PR DESCRIPTION
<!-- 작성 예시 -->

<!-- # 문제 및 해결방안 -->
<!-- - 간략한 문제 설명 (문제 관련 링크 등등) -->
<!-- - 해당 문제를 해결한 방법에 대한 설명 -->

<!-- # 구현 설명 -->
<!-- - 동작 방식 등 코드적으로 구현한 방법에 대한 설명 -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 문제 및 해결방안

- CreateRoomLayout에서 useEffect와 useRouter를 사용중인데, `use client` 선언이 되지 않아 발생하는 에러를 수정하였습니다.

## ✍️ 구현 설명

- 출발지 설정 API를 연동하였습니다.
- 요청 성공시 router를 통해 share 페이지로 이동하도록 하였습니다.

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
