### PR TITLE
feat(web): 멤버용 온보딩 화면 추가

### DIFF
--- a/apps/web/app/api/rooms/[roomId]/route.ts
+++ b/apps/web/app/api/rooms/[roomId]/route.ts
@@ -1,0 +1,23 @@
+import { RoomInfoResponse } from "@/api/types/room/index.type";
+import { getRequest } from "@repo/shared/axios";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> }
+) {
+  try {
+    const { roomId } = await params;
+    const data = await getRequest<RoomInfoResponse>({
+      url: `${process.env.NEXT_PUBLIC_BASE_URL}/rooms/${roomId}`,
+    });
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch data" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/member/[roomId]/page.tsx
+++ b/apps/web/app/member/[roomId]/page.tsx
@@ -1,0 +1,11 @@
+import Page from "@/pages/MemberOnboarding/Page";
+
+export default async function MemberOnboardingPage({
+  params,
+}: {
+  params: Promise<{ roomId: string }>;
+}) {
+  const { roomId } = await params;
+
+  return <Page roomId={roomId} />;
+}

--- a/apps/web/src/api/types/room/index.type.ts
+++ b/apps/web/src/api/types/room/index.type.ts
@@ -1,0 +1,17 @@
+import { ICommon } from "../common/common.type";
+
+export interface MemberInfo {
+  id: string;
+  nickname: string;
+  profile: string;
+  role: string;
+}
+
+export interface RoomInfo {
+  id: string;
+  roomName: string;
+  capacity: number;
+  member: MemberInfo;
+}
+
+export type RoomInfoResponse = ICommon<RoomInfo>;

--- a/apps/web/src/components/member-onboarding/index.tsx
+++ b/apps/web/src/components/member-onboarding/index.tsx
@@ -1,0 +1,63 @@
+import { Button, Flex, Text } from "@repo/ui/components";
+import Image from "next/image";
+import * as Style from "./style.css";
+
+interface MemberOnboardingProps {
+  roomId: string;
+  roomName: string;
+}
+
+const MemberOnboarding = ({ roomName }: MemberOnboardingProps) => {
+  const descriptions = [
+    "내 프로필을 만들고 출발지를 입력해요",
+    "중간장소 후보를 확인하고 추가해요",
+    "투표 안한 친구 들을 독촉해요",
+  ];
+
+  return (
+    <Flex
+      direction="column"
+      align="center"
+      justify="between"
+      className={Style.background}
+    >
+      <Flex direction="column" align="center" justify="between" gap={80}>
+        <div className={Style.header}>
+          <Text variant="title3" className={Style.speachBubble}>
+            {roomName}
+            <div className={Style.speachBubbleTail} />
+          </Text>
+          <Text variant="heading3">모임 초대장이 도착했어요</Text>
+        </div>
+
+        <Image
+          src="/images/create-room/main.svg"
+          alt="invitation character image"
+          width={160}
+          height={160}
+          priority
+        />
+
+        <Flex
+          as="ul"
+          direction="column"
+          gap={16}
+          className={Style.descriptionContainer}
+        >
+          {descriptions.map((description, index) => (
+            <Flex as="li" key={index} gap={12} align="center">
+              <div className={Style.numbering}>{index + 1}</div>
+              <Text as="p" variant="caption">
+                {description}
+              </Text>
+            </Flex>
+          ))}
+        </Flex>
+      </Flex>
+
+      <Button variant="secondary">약속방 참여하기</Button>
+    </Flex>
+  );
+};
+
+export default MemberOnboarding;

--- a/apps/web/src/components/member-onboarding/style.css.ts
+++ b/apps/web/src/components/member-onboarding/style.css.ts
@@ -1,0 +1,46 @@
+import { theme } from "@repo/ui/tokens";
+import { style } from "@vanilla-extract/css";
+
+export const background = style({
+  padding: "68px 20px 20px 20px",
+  width: "100%",
+  height: "100dvh",
+  background: `linear-gradient(-170deg, ${theme.colors.yellow5} 0%, ${theme.colors.orange5} 50%, ${theme.colors.bg.base} 95%)`,
+});
+
+export const header = style({});
+
+export const speachBubble = style({
+  marginBottom: "8px",
+  position: "relative",
+  display: "block",
+  padding: "8px 10px",
+  width: "fit-content",
+  borderRadius: "12px",
+  background: theme.colors.bg1,
+  backdropFilter: "blur(15px)",
+});
+
+export const speachBubbleTail = style({
+  position: "absolute",
+  width: "8px",
+  height: "8px",
+  bottom: "-4px",
+  left: "40%",
+  background: theme.colors.bg1,
+  transform: "rotate(45deg)",
+  borderBottomRightRadius: "2px",
+});
+
+export const descriptionContainer = style({
+  color: theme.colors.text.caption,
+});
+
+export const numbering = style({
+  padding: "5px 9px",
+  fontSize: "11px",
+  textAlign: "center",
+  backgroundColor: theme.colors.navy,
+  color: theme.colors.text.white,
+  borderRadius: "100%",
+});

--- a/apps/web/src/hooks/api/useRoomInfo.ts
+++ b/apps/web/src/hooks/api/useRoomInfo.ts
@@ -1,0 +1,23 @@
+import { RoomInfoResponse } from "@/api/types/room/index.type";
+import { useQuery } from "@repo/shared/tanstack-query";
+
+export const getRoomInfo = async (roomId: string) => {
+  const response = await fetch(`/api/rooms/${roomId}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+  return response.json();
+};
+
+export const useRoomInfo = (roomId: string) => {
+  return useQuery<RoomInfoResponse>({
+    queryKey: ["RoomInfo", roomId],
+    queryFn: () => getRoomInfo(roomId),
+    retry: false,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+};
+// "34f25ea7-176a-44ee-8e7e-45842cd2f790"

--- a/apps/web/src/pages/MemberOnboarding/Page.tsx
+++ b/apps/web/src/pages/MemberOnboarding/Page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import MemberOnboarding from "@/components/member-onboarding";
+import { useRoomInfo } from "@/hooks/api/useRoomInfo";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+interface Props {
+  roomId: string;
+}
+
+export default function Page({ roomId }: Props) {
+  const router = useRouter();
+  const { data, isError } = useRoomInfo(roomId);
+
+  useEffect(() => {
+    if (isError) router.push("/");
+  }, [router, isError]);
+
+  return (
+    data && <MemberOnboarding roomId={roomId} roomName={data.data.roomName} />
+  );
+}


### PR DESCRIPTION
<!-- 작성 예시 -->

<!-- # 문제 및 해결방안 -->
<!-- - 간략한 문제 설명 (문제 관련 링크 등등) -->
<!-- - 해당 문제를 해결한 방법에 대한 설명 -->

<!-- # 구현 설명 -->
<!-- - 동작 방식 등 코드적으로 구현한 방법에 대한 설명 -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 문제 및 해결방안

- 

## ✍️ 구현 설명

- 멤버용 온보딩 화면을 추가하였습니다.
- React Query를 활용하여 약속방 정보를 API를 통해 호출하고 캐싱하도록 설정하였습니다.

### 📷 이미지 첨부 (Option)

![스크린샷 2025-03-21 오후 5 08 36](https://github.com/user-attachments/assets/d9c4eeab-90b7-4f88-9ff6-952897ab7885)

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
