### PR TITLE
fix(web): 멤버용 온보딩 페이지 빌드 에러 수정

### DIFF
--- a/apps/web/app/member/[roomId]/page.tsx
+++ b/apps/web/app/member/[roomId]/page.tsx
@@ -1,11 +1,3 @@
 import Page from "@/pages/MemberOnboarding/Page";
 
-export default async function MemberOnboardingPage({
-  params,
-}: {
-  params: Promise<{ roomId: string }>;
-}) {
-  const { roomId } = await params;
-
-  return <Page roomId={roomId} />;
-}
+export default Page;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,7 +21,8 @@
     "@vanilla-extract/recipes": "^0.5.5",
     "next": "^15.1.6",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-error-boundary": "^5.0.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/apps/web/src/components/member-onboarding/index.tsx
+++ b/apps/web/src/components/member-onboarding/index.tsx
@@ -1,13 +1,17 @@
+"use client";
+
 import { Button, Flex, Text } from "@repo/ui/components";
 import Image from "next/image";
 import * as Style from "./style.css";
+import { useRoomInfo } from "@/hooks/api/useRoomInfo";
 
 interface MemberOnboardingProps {
   roomId: string;
-  roomName: string;
 }
 
-const MemberOnboarding = ({ roomName }: MemberOnboardingProps) => {
+const MemberOnboarding = ({ roomId }: MemberOnboardingProps) => {
+  const { data } = useRoomInfo(roomId);
+
   const descriptions = [
     "내 프로필을 만들고 출발지를 입력해요",
     "중간장소 후보를 확인하고 추가해요",
@@ -24,7 +28,11 @@ const MemberOnboarding = ({ roomName }: MemberOnboardingProps) => {
       <Flex direction="column" align="center" justify="between" gap={80}>
         <div className={Style.header}>
           <Text variant="title3" className={Style.speachBubble}>
-            {roomName}
+            {data ? (
+              data.data.roomName
+            ) : (
+              <div style={{ height: "16px", width: "20px" }} /> // TODO: 스켈레톤 적용
+            )}
             <div className={Style.speachBubbleTail} />
           </Text>
           <Text variant="heading3">모임 초대장이 도착했어요</Text>

--- a/apps/web/src/hooks/api/useRoomInfo.ts
+++ b/apps/web/src/hooks/api/useRoomInfo.ts
@@ -2,13 +2,18 @@ import { RoomInfoResponse } from "@/api/types/room/index.type";
 import { useQuery } from "@repo/shared/tanstack-query";
 
 export const getRoomInfo = async (roomId: string) => {
-  const response = await fetch(`/api/rooms/${roomId}`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
-  return response.json();
+  try {
+    const response = await fetch(`/api/rooms/${roomId}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    return response.json();
+  } catch (error) {
+    console.error("Error: ", error);
+    throw new Error("방 정보를 불러올 수 없습니다.");
+  }
 };
 
 export const useRoomInfo = (roomId: string) => {
@@ -20,4 +25,3 @@ export const useRoomInfo = (roomId: string) => {
     gcTime: Infinity,
   });
 };
-// "34f25ea7-176a-44ee-8e7e-45842cd2f790"

--- a/apps/web/src/pages/MemberOnboarding/Page.tsx
+++ b/apps/web/src/pages/MemberOnboarding/Page.tsx
@@ -1,23 +1,20 @@
 "use client";
 
 import MemberOnboarding from "@/components/member-onboarding";
-import { useRoomInfo } from "@/hooks/api/useRoomInfo";
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useParams } from "next/navigation";
+import { ErrorBoundary } from "react-error-boundary";
 
-interface Props {
-  roomId: string;
-}
+export default function Page() {
+  const params = useParams<{
+    roomId: string;
+  }>()!;
 
-export default function Page({ roomId }: Props) {
-  const router = useRouter();
-  const { data, isError } = useRoomInfo(roomId);
-
-  useEffect(() => {
-    if (isError) router.push("/");
-  }, [router, isError]);
+  if (!params) return null; // NOTE: 초기 컴포넌트 로드시 params가 null일 수 있음
 
   return (
-    data && <MemberOnboarding roomId={roomId} roomName={data.data.roomName} />
+    // TODO: fallback UI 추가
+    <ErrorBoundary fallback={<>유효하지 않은 초대장입니다.</>}>
+      <MemberOnboarding roomId={params?.roomId || ""} />
+    </ErrorBoundary>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      react-error-boundary:
+        specifier: ^5.0.0
+        version: 5.0.0(react@19.0.0)
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -4447,6 +4450,11 @@ packages:
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
       react: ^19.0.0
+
+  react-error-boundary@5.0.0:
+    resolution: {integrity: sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -10131,6 +10139,11 @@ snapshots:
     dependencies:
       react: 19.0.0
       scheduler: 0.25.0
+
+  react-error-boundary@5.0.0(react@19.0.0):
+    dependencies:
+      '@babel/runtime': 7.26.9
+      react: 19.0.0
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
<!-- 작성 예시 -->

<!-- # 문제 및 해결방안 -->
<!-- - 간략한 문제 설명 (문제 관련 링크 등등) -->
<!-- - 해당 문제를 해결한 방법에 대한 설명 -->

<!-- # 구현 설명 -->
<!-- - 동작 방식 등 코드적으로 구현한 방법에 대한 설명 -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 문제 및 해결방안

- NextJS의 dynamic routing에서 parameter를 받아와 react-query로 API 요청을 보낼 때 sync error로 인한 빌드 에러를 수정하였습니다.
  - 서버 컴포넌트에서 QueryProvider가 초기화되지 않은 시점에서 useQuery를 사용하여 에러가 발생하였습니다. (dev 환경에서는 문제가 되지 않았지만 빌드 과정에서 에러 발생)
  - 따라서 해당 컴포넌트를 클라이언트 컴포넌트로 변경하였습니다.
- 추후 에러에 대한 대응을 선언적으로 하기 위해 React Error Boundary를 설치하였습니다.

## ✍️ 구현 설명

-

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

- 온보딩 화면에서는 방의 이름만을 필요로 하기 때문에 단순 fetch를 통해 서버 컴포넌트로 구현하는 것도 괜찮을 것 같기도 합니다.

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
