### PR TITLE
feat(web) : 동적 라우팅 및 사용자 역할에 따른 UI 분기 처리

### DIFF
--- a/apps/web/app/find-midpoint/page.tsx
+++ b/apps/web/app/find-midpoint/page.tsx
@@ -1,7 +1,0 @@
-import FindingMidPoint from "@/components/midpoint-result/FindingMidPoint";
-
-const FindMidPointPage = () => {
-  return <FindingMidPoint />;
-};
-
-export default FindMidPointPage;

--- a/apps/web/app/share/[roomId]/page.tsx
+++ b/apps/web/app/share/[roomId]/page.tsx
@@ -2,10 +2,13 @@ import FindingMidPoint from "@/components/midpoint-result/FindingMidPoint";
 
 export default function ShareRoomPage({
   params,
+  searchParams,
 }: {
   params: { roomId: string };
+  searchParams?: { role?: string };
 }) {
   const { roomId } = params;
+  const isLeader = searchParams?.role === "leader";
 
-  return <FindingMidPoint roomId={roomId} />;
+  return <FindingMidPoint roomId={roomId} isLeader={isLeader} />;
 }

--- a/apps/web/app/share/[roomId]/page.tsx
+++ b/apps/web/app/share/[roomId]/page.tsx
@@ -1,0 +1,11 @@
+import FindingMidPoint from "@/components/midpoint-result/FindingMidPoint";
+
+export default function ShareRoomPage({
+  params,
+}: {
+  params: { roomId: string };
+}) {
+  const { roomId } = params;
+
+  return <FindingMidPoint roomId={roomId} />;
+}

--- a/apps/web/app/share/page.tsx
+++ b/apps/web/app/share/page.tsx
@@ -1,3 +1,0 @@
-import Page from "@pages/Share/Page";
-
-export default Page;

--- a/apps/web/src/components/midpoint-result/FindingMidPoint.tsx
+++ b/apps/web/src/components/midpoint-result/FindingMidPoint.tsx
@@ -18,15 +18,19 @@ import {
 } from "@/utils/location";
 import StartBanner from "./organisms/StartBanner";
 
-const FindingMidPoint = () => {
+interface FindingMidPointProps {
+  roomId: string;
+}
+
+const FindingMidPoint = ({ roomId }: FindingMidPointProps) => {
   const { data: centroid, isLoading: centroidLoading } =
-    useLocationCentroid("ConvH");
+    useLocationCentroid(roomId);
   const { data: convH, isLoading: convHLoading } =
-    useLocationConvexHull("ConvH");
+    useLocationConvexHull(roomId);
   const markerData = convH ? convertToMarkerData(convH) : [];
   const polygonPath = convH ? convertToPolygonPath(convH) : [];
   const centerMarkerData = centroid
-    ? convertToCenterMarkerData({ ...centroid, roomId: "test_pt" })
+    ? convertToCenterMarkerData({ ...centroid, roomId: roomId })
     : undefined;
   const [isOverlayVisible, setIsOverlayVisible] = useState(true);
   const [isBannerVisible, setIsBannerVisible] = useState(true);
@@ -42,8 +46,7 @@ const FindingMidPoint = () => {
     return <div>Loading...</div>;
   }
 
-  const roomId = centerMarkerData?.roomId || "test_pt";
-  const roomName = "디프만 모각자"; // TODO: 추후 방생성 후 연동해야함
+  const roomName = "디프만 모각자"; // 소정 TODO: 서버한테 달라하기
 
   return (
     <div className={mapContainer}>
@@ -70,6 +73,7 @@ const FindingMidPoint = () => {
           <div className={overlayStyle} onClick={handleClick} />
         )}
         <ParticipantBottomSheet
+          roomId={roomId}
           totalParticipants={markerData.length}
           banner={
             isOverlayVisible && (

--- a/apps/web/src/components/midpoint-result/FindingMidPoint.tsx
+++ b/apps/web/src/components/midpoint-result/FindingMidPoint.tsx
@@ -20,9 +20,13 @@ import StartBanner from "./organisms/StartBanner";
 
 interface FindingMidPointProps {
   roomId: string;
+  isLeader?: boolean;
 }
 
-const FindingMidPoint = ({ roomId }: FindingMidPointProps) => {
+const FindingMidPoint = ({
+  roomId,
+  isLeader = false,
+}: FindingMidPointProps) => {
   const { data: centroid, isLoading: centroidLoading } =
     useLocationCentroid(roomId);
   const { data: convH, isLoading: convHLoading } =
@@ -81,6 +85,7 @@ const FindingMidPoint = ({ roomId }: FindingMidPointProps) => {
                 isVisible={isBannerVisible}
                 onClose={handleBannerClose}
                 onDeleteClick={handleClick}
+                isLeader={isLeader}
               />
             )
           }

--- a/apps/web/src/components/midpoint-result/FindingMidPoint.tsx
+++ b/apps/web/src/components/midpoint-result/FindingMidPoint.tsx
@@ -5,7 +5,12 @@ import MapHeader from "./organisms/MapHeader";
 import RefreshCenterButton from "./organisms/RefreshCenterButton";
 import { Flex } from "@repo/ui/components";
 import ParticipantBottomSheet from "@/components/midpoint-result/organisms/ParticipantBottomSheet";
-import { refreshStyle, mapContainer, overlayStyle } from "./style.css";
+import {
+  refreshStyle,
+  mapContainer,
+  overlayStyle,
+  AddLocationButtonPositionStyle,
+} from "./style.css";
 import {
   useLocationCentroid,
   useLocationConvexHull,
@@ -17,6 +22,7 @@ import {
   convertToCenterMarkerData,
 } from "@/utils/location";
 import StartBanner from "./organisms/StartBanner";
+import AddLocationButton from "./organisms/AddLocationButton";
 
 interface FindingMidPointProps {
   roomId: string;
@@ -56,6 +62,7 @@ const FindingMidPoint = ({
     <div className={mapContainer}>
       <Flex direction="column">
         <MapHeader title={roomName} />
+
         <div className={refreshStyle}>
           {centerMarkerData && (
             <RefreshCenterButton
@@ -76,6 +83,9 @@ const FindingMidPoint = ({
         {isOverlayVisible && (
           <div className={overlayStyle} onClick={handleClick} />
         )}
+        <Flex className={AddLocationButtonPositionStyle}>
+          <AddLocationButton />
+        </Flex>
         <ParticipantBottomSheet
           roomId={roomId}
           totalParticipants={markerData.length}

--- a/apps/web/src/components/midpoint-result/MidPointResult.tsx
+++ b/apps/web/src/components/midpoint-result/MidPointResult.tsx
@@ -29,11 +29,12 @@ const MidPointResult = () => {
     latitude: firstStation?.station.latitude,
     longitude: firstStation?.station.longitude,
   };
+  const roomId = "test_pt";
 
   const { data: simpleData } = useSimpleTransfer(
     firstStation?.station.id ?? 59,
     {
-      roomId: "test_pt",
+      roomId: roomId,
       memberId: "1",
     }
   );
@@ -41,7 +42,7 @@ const MidPointResult = () => {
   const { data: complexData } = useComplexTransfer(
     firstStation?.station.id ?? 59,
     {
-      roomId: "test_pt",
+      roomId: roomId,
       memberId: "1",
     }
   );
@@ -65,6 +66,7 @@ const MidPointResult = () => {
         )}
         <Flex>
           <ResultBottomSheet
+            roomId={roomId}
             totalTime={simpleData?.data?.totalTime}
             transferCount={simpleData?.data?.transferCount}
             totalDistance={complexData?.data?.parsedItinerary?.totalDistance}

--- a/apps/web/src/components/midpoint-result/organisms/AddLocationButton.tsx
+++ b/apps/web/src/components/midpoint-result/organisms/AddLocationButton.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { Text, Flex } from "@repo/ui/components";
+import { theme } from "@repo/ui/tokens";
+import { AddLocationButtonStyle } from "./styles.css";
+
+const AddLocationButton = () => {
+  return (
+    <Flex className={AddLocationButtonStyle}>
+      <Text variant="title4" color={theme.colors.text1}>
+        원하는 모임 장소 추가
+      </Text>
+    </Flex>
+  );
+};
+
+export default AddLocationButton;

--- a/apps/web/src/components/midpoint-result/organisms/ResultBottomSheet.tsx
+++ b/apps/web/src/components/midpoint-result/organisms/ResultBottomSheet.tsx
@@ -9,6 +9,8 @@ import { metersToKilometersString } from "@/utils/meterToKilometers";
 import TransportBar from "./TransporBar";
 import { parseSubwayLineNumber } from "@/utils/subway";
 import { ReactNode } from "react";
+import KakaoTalkShareButton from "@/components/share-room/molecule/KakaoTalkShareButton";
+import { KAKAO_TEMPLATE_IDS } from "@/constants/kakao-template";
 
 interface ResultBottomSheetProps {
   totalTime?: number;
@@ -23,6 +25,7 @@ interface ResultBottomSheetProps {
   }[];
   banner?: ReactNode;
   bannerBottom?: string;
+  roomId?: string;
 }
 
 const ResultBottomSheet = ({
@@ -32,6 +35,7 @@ const ResultBottomSheet = ({
   legs = [],
   banner,
   bannerBottom,
+  roomId = "",
 }: ResultBottomSheetProps) => {
   const onClickCopyLink = () => {
     alert("링크 복사하기 클릭!");
@@ -135,9 +139,15 @@ const ResultBottomSheet = ({
         </Flex>
       </div>
       <Flex as="div" direction="column" gap={20}>
-        <Button onClick={onClickCopyLink}>
-          <Text variant="title3">결과 공유하기</Text>
-        </Button>
+        <KakaoTalkShareButton
+          variant="primary"
+          templateId={KAKAO_TEMPLATE_IDS.FINISH}
+          templateArgs={{
+            roomId,
+          }}
+        >
+          결과 공유하기
+        </KakaoTalkShareButton>
       </Flex>
     </AnimationBottomSheet>
   );

--- a/apps/web/src/components/midpoint-result/organisms/StartBanner.tsx
+++ b/apps/web/src/components/midpoint-result/organisms/StartBanner.tsx
@@ -7,15 +7,17 @@ interface StartBannerProps {
   onClose: () => void;
   onDeleteClick: () => void;
   isVisible?: boolean;
+  isLeader?: boolean;
 }
 
 const StartBanner = ({
   onClose,
   isVisible = true,
   onDeleteClick,
+  isLeader = false,
 }: StartBannerProps) => {
-  const title = "출발지 입력 완료!";
-  const place = "디프만 모각작";
+  const title = isLeader ? "모임이 생성 됐어요!" : "출발지 입력 완료!";
+  const place = "디프만 모각작"; // 소정 TODO
 
   return (
     <div className={bannerContainerStyle}>

--- a/apps/web/src/components/midpoint-result/organisms/styles.css.ts
+++ b/apps/web/src/components/midpoint-result/organisms/styles.css.ts
@@ -200,3 +200,14 @@ export const timeDisplayStyle = style({
   fontWeight: "bold",
   flexShrink: 0,
 });
+
+export const AddLocationButtonStyle = style({
+  background: theme.colors.orange40,
+  padding: "0 12px",
+  width: "150px",
+  height: "36px",
+  borderRadius: "100px",
+  justifyContent: "center",
+  alignItems: "center",
+  cursor: "pointer",
+});

--- a/apps/web/src/components/midpoint-result/style.css.ts
+++ b/apps/web/src/components/midpoint-result/style.css.ts
@@ -26,3 +26,10 @@ export const refreshStyle = style({
   transform: "translateX(-50%)",
   zIndex: zIndex.floating,
 });
+
+export const AddLocationButtonPositionStyle = style({
+  position: "relative",
+  bottom: "220px",
+  justifyContent: "flex-end",
+  paddingRight: "20px",
+});

--- a/apps/web/src/components/search-place-bottom-sheet/index.tsx
+++ b/apps/web/src/components/search-place-bottom-sheet/index.tsx
@@ -147,9 +147,8 @@ const SearchPlaceBottomSheet = ({
   useEffect(() => {
     if (!isSuccess) return;
 
-    router.push(`/share/${roomId}`);
+    router.push(`/share/${roomId}?role=${encodeURIComponent("leader")}`);
   }, [router, isSuccess, roomId]);
-  console.log("roomId", roomId);
 
   return (
     <>

--- a/apps/web/src/components/search-place-bottom-sheet/index.tsx
+++ b/apps/web/src/components/search-place-bottom-sheet/index.tsx
@@ -147,8 +147,9 @@ const SearchPlaceBottomSheet = ({
   useEffect(() => {
     if (!isSuccess) return;
 
-    router.push("/share");
-  }, [router, isSuccess]);
+    router.push(`/share/${roomId}`);
+  }, [router, isSuccess, roomId]);
+  console.log("roomId", roomId);
 
   return (
     <>


### PR DESCRIPTION
## 🤔 문제 및 해결방안

-

## ✍️ 구현 설명

- /find-midpoint 페이지를 삭제하고 /share/[roomId] 동적 라우팅 구조로 변경
- URL 쿼리 파라미터(?role=leader)를 통해 사용자 역할 정보 전달
- StartBanner 컴포넌트에 isLeader prop 추가하여 역할에 따라 다른 메시지 표시
- FindingMidPoint 컴포넌트에 roomId와 isLeader prop 추가
- 카카오톡 공유 기능 개선 (KakaoTalkShareButton 연동)

### 📷 이미지 첨부 (Option)


https://github.com/user-attachments/assets/0bb4f708-707a-435e-85d4-c6d2791f4950


### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
