### PR TITLE
feat(web): 멤버 플로우에 출발지 설정 추가

### DIFF
--- a/apps/web/src/components/join-room/templates/JoinRoomLayout.tsx
+++ b/apps/web/src/components/join-room/templates/JoinRoomLayout.tsx
@@ -10,6 +10,7 @@ import CreateProfile from "../organisms/create-profile/CreateProfile";
 import { useMoveVisualViewportTop } from "@/hooks/useMoveVisualViewportTop";
 import { useJoinRoom } from "@/hooks/api/useJoinRoom";
 import { useParams, useRouter } from "next/navigation";
+import SelectStartPlace from "@/components/create-room/organisms/select-start-place/SelectStartPlace";
 
 interface IJoinRoomLayoutProps {
   randomProfile: IRaondomProfile;
@@ -68,13 +69,13 @@ const JoinRoomLayout = ({ randomProfile }: IJoinRoomLayoutProps) => {
           setProfileValue={setProfileValue}
         />
       )}
-      {step === 2 && data && <div>형 담당</div>}
-      {/* 
-      props는 이거 복붙 하면 됨.
-      roomId={roomId}
-      memberImgUrl={data.data.profile} 
-      memberId={data.data.id}
-      */}
+      {step === 2 && data && roomId && (
+        <SelectStartPlace
+          roomId={roomId as string}
+          memberImgUrl={data.data.profile}
+          memberId={data.data.id}
+        />
+      )}
     </div>
   );
 };

--- a/apps/web/src/components/member-onboarding/index.tsx
+++ b/apps/web/src/components/member-onboarding/index.tsx
@@ -4,19 +4,27 @@ import { Button, Flex, LoadingDots, Text } from "@repo/ui/components";
 import Image from "next/image";
 import * as Style from "./style.css";
 import { useRoomInfo } from "@/hooks/api/useRoomInfo";
+import { useRouter } from "next/navigation";
+import { usePressEffect } from "@repo/motion";
 
 interface MemberOnboardingProps {
   roomId: string;
 }
 
 const MemberOnboarding = ({ roomId }: MemberOnboardingProps) => {
+  const router = useRouter();
   const { data } = useRoomInfo(roomId);
+  const { backgroundRef, containerRef, pressProps } = usePressEffect();
 
   const descriptions = [
     "내 프로필을 만들고 출발지를 입력해요",
     "중간장소 후보를 확인하고 추가해요",
     "투표 안한 친구 들을 독촉해요",
   ];
+
+  const handleClickJoin = () => {
+    router.push(`/member/${roomId}/profile`);
+  };
 
   return (
     <Flex
@@ -59,7 +67,17 @@ const MemberOnboarding = ({ roomId }: MemberOnboardingProps) => {
         </Flex>
       </Flex>
 
-      <Button variant="secondary">약속방 참여하기</Button>
+      <div className={Style.buttonContainer}>
+        <Button
+          variant="secondary"
+          ref={containerRef}
+          {...pressProps}
+          onClick={handleClickJoin}
+        >
+          <div ref={backgroundRef} className={Style.buttonBackground} />
+          약속방 참여하기
+        </Button>
+      </div>
     </Flex>
   );
 };

--- a/apps/web/src/components/member-onboarding/style.css.ts
+++ b/apps/web/src/components/member-onboarding/style.css.ts
@@ -44,3 +44,25 @@ export const numbering = style({
   color: theme.colors.text.white,
   borderRadius: "100%",
 });
+
+export const buttonContainer = style({
+  padding: "16px 20px",
+  width: "100%",
+});
+
+export const button = style({
+  position: "relative",
+  fontSize: 16,
+  fontWeight: 600,
+});
+
+export const buttonBackground = style({
+  position: "absolute",
+  top: 0,
+  left: 0,
+  width: "100%",
+  height: "100%",
+  opacity: 0,
+  backgroundColor: "rgba(0, 0, 0, 0.1)",
+  zIndex: -1,
+});

--- a/apps/web/src/components/search-place-bottom-sheet/index.tsx
+++ b/apps/web/src/components/search-place-bottom-sheet/index.tsx
@@ -163,7 +163,6 @@ const SearchPlaceBottomSheet = ({
   useEffect(() => {
     if (!isSuccess || !pathname) return;
 
-    console.log(pathname);
     const roleQueryParam = pathname.includes("member")
       ? ""
       : `?role=${encodeURIComponent("leader")}`;

--- a/apps/web/src/components/search-place-bottom-sheet/index.tsx
+++ b/apps/web/src/components/search-place-bottom-sheet/index.tsx
@@ -25,7 +25,7 @@ import {
 import { convertWGS84ToLatLng, getFullAddressAndTitle } from "@/utils/location";
 import { useCurrentLocation } from "@/hooks/api/useCurrentLocation";
 import { useSelectStartPlace } from "@/hooks/api/useSelectStartPlace";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import Image from "next/image";
 import { useSetStartLocation } from "@/hooks/api/useStartLocation";
 
@@ -41,6 +41,7 @@ const SearchPlaceBottomSheet = ({
   memberImgUrl,
 }: SearchPlaceBottomSheetProps) => {
   const router = useRouter();
+  const pathname = usePathname();
   const { mutate, isSuccess } = useSelectStartPlace();
   const [isSearching, setIsSearching] = useState<boolean>(false);
   const [place, setPlace] = useState<Place | null>(null);
@@ -160,10 +161,14 @@ const SearchPlaceBottomSheet = ({
   }, [place, moveTo, marker]);
 
   useEffect(() => {
-    if (!isSuccess) return;
+    if (!isSuccess || !pathname) return;
 
-    router.push(`/share/${roomId}?role=${encodeURIComponent("leader")}`);
-  }, [router, isSuccess, roomId]);
+    console.log(pathname);
+    const roleQueryParam = pathname.includes("member")
+      ? ""
+      : `?role=${encodeURIComponent("leader")}`;
+    router.push(`/share/${roomId}${roleQueryParam}`);
+  }, [router, pathname, isSuccess, roomId]);
 
   return (
     <>


### PR DESCRIPTION
<!-- 작성 예시 -->

<!-- # 문제 및 해결방안 -->
<!-- - 간략한 문제 설명 (문제 관련 링크 등등) -->
<!-- - 해당 문제를 해결한 방법에 대한 설명 -->

<!-- # 구현 설명 -->
<!-- - 동작 방식 등 코드적으로 구현한 방법에 대한 설명 -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 문제 및 해결방안

-

## ✍️ 구현 설명

- 멤버용 플로우에서 프로필 생성 후 출발지를 설정할 수 있도록 로직을 추가하였습니다.

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
