### PR TITLE
fix: 멤버 위치 마커 표시, memberId 전달

### DIFF
--- a/apps/web/app/share/[roomId]/page.tsx
+++ b/apps/web/app/share/[roomId]/page.tsx
@@ -5,10 +5,14 @@ export default async function ShareRoomPage({
   searchParams,
 }: {
   params: Promise<{ roomId: string }>;
-  searchParams?: Promise<{ role?: string }>;
+  searchParams?: Promise<{ role?: string; memberId?: string }>;
 }) {
   const { roomId } = await params;
-  const isLeader = (await searchParams)?.role === "leader";
+  const resolvedSearchParams = await searchParams;
+  const isLeader = resolvedSearchParams?.role === "leader";
+  const memberId = resolvedSearchParams?.memberId || "";
 
-  return <FindingMidPoint roomId={roomId} isLeader={isLeader} />;
+  return (
+    <FindingMidPoint roomId={roomId} isLeader={isLeader} memberId={memberId} />
+  );
 }

--- a/apps/web/src/api/types/locations/index.types.ts
+++ b/apps/web/src/api/types/locations/index.types.ts
@@ -5,12 +5,14 @@ export interface LocationsRequestProps {
   memberId: string;
   latitude: number;
   longitude: number;
+  name: string; // TODO소정 -> 준영 확인 필요!!! Address 추가로 인해 추가되었는데 확인 바람!!!
 }
 
 export interface Locations {
   roomId: string;
   latitude: number;
   longitude: number;
+  imageUrl?: string;
 }
 
 export type LocationsResponse = ICommon<Locations>;

--- a/apps/web/src/components/profile-list/organisms/profile-list-footer/ProfileListFooter.tsx
+++ b/apps/web/src/components/profile-list/organisms/profile-list-footer/ProfileListFooter.tsx
@@ -14,7 +14,7 @@ const ProfileListFooter = ({ currentMemberId }: IProfileListFooterProps) => {
 
   const handleNextClick = () => {
     if (currentMemberId) {
-      router.push(`/result/${roomId}?memberId=${currentMemberId}`);
+      router.push(`/share/${roomId}?memberId=${currentMemberId}`);
     }
   };
 

--- a/apps/web/src/components/search-place-bottom-sheet/index.tsx
+++ b/apps/web/src/components/search-place-bottom-sheet/index.tsx
@@ -110,6 +110,13 @@ const SearchPlaceBottomSheet = ({
 
   const onClickSelectPlace = () => {
     if (!place) return;
+
+    marker.cleanUp();
+    marker.create({
+      latitude: Number(place.mapy),
+      longitude: Number(place.mapx),
+    });
+
     setStartLocation({
       roomId,
       latitude: Number(place.mapy),
@@ -122,9 +129,8 @@ const SearchPlaceBottomSheet = ({
       memberId,
       latitude: Number(place.mapy),
       longitude: Number(place.mapx),
+      name: place.address,
     });
-
-    // router.push(`/share/${roomId}`);
   };
 
   const onClickRemovePlace = () => {
@@ -166,10 +172,10 @@ const SearchPlaceBottomSheet = ({
     if (!isSuccess || !pathname) return;
 
     const roleQueryParam = pathname.includes("create-room")
-      ? `?role=${encodeURIComponent("leader")}`
-      : "";
+      ? `?memberId=${encodeURIComponent(memberId)}&role=${encodeURIComponent("leader")}`
+      : `?memberId=${encodeURIComponent(memberId)}`;
     router.push(`/share/${roomId}${roleQueryParam}`);
-  }, [router, pathname, isSuccess, roomId]);
+  }, [router, pathname, isSuccess, roomId, memberId]);
 
   return (
     <>

--- a/apps/web/src/constants/api/index.ts
+++ b/apps/web/src/constants/api/index.ts
@@ -5,6 +5,7 @@
 export const API_URLS = {
   GET_CONVEXHULL: "/locations/ConvH/",
   GET_CENTROID: "/locations/centroid/",
+  GET_LOCATION: "/locations/",
   GET_RANDOM_PROFILE: "/rooms/profile/random",
   POST_CREATE_ROOM: "/rooms",
   GET_ROOM_INFO: "/rooms",

--- a/apps/web/src/hooks/api/useLocation.ts
+++ b/apps/web/src/hooks/api/useLocation.ts
@@ -4,6 +4,9 @@ import type {
   LocationCentroid,
   LocationConvexHull,
 } from "@/api/types/location/location.types";
+import { LocationsResponse } from "@/api/types/locations/index.types";
+import { getRequest } from "@repo/shared/axios";
+import { API_URLS } from "@/constants/api";
 
 export const useLocationCentroid = (roomId: string) => {
   const result = useQuery<
@@ -26,7 +29,7 @@ export const useLocationCentroid = (roomId: string) => {
     return {
       roomId: apiData.roomId || roomId,
       latitude: apiData.latitude, // 3.20 수정완료
-      longitude: apiData.longitude, //
+      longitude: apiData.longitude,
     };
   })();
 
@@ -78,4 +81,14 @@ export const useLocationConvexHull = (roomId: string) => {
     ...result,
     data: transformedData,
   };
+};
+
+export const useMemberLocation = (roomId: string, memberId: string) => {
+  return useQuery({
+    queryKey: ["locations", roomId, memberId],
+    queryFn: () =>
+      getRequest<LocationsResponse>({
+        url: `${API_URLS.GET_LOCATION}${roomId}/${memberId}`,
+      }),
+  });
 };

--- a/apps/web/src/hooks/api/useSelectStartPlace.ts
+++ b/apps/web/src/hooks/api/useSelectStartPlace.ts
@@ -3,7 +3,7 @@ import { useMutation } from "@repo/shared/tanstack-query";
 
 const selectStartPlace = async (requestBody: LocationsRequestProps) => {
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}/v1/api/locations`,
+    `${process.env.NEXT_PUBLIC_BASE_URL}/locations`,
     {
       method: "POST",
       headers: {

--- a/packages/naver-map/src/types.ts
+++ b/packages/naver-map/src/types.ts
@@ -10,6 +10,11 @@ export interface NaverMapProps {
   markerData?: MarkerDataCollection | MarkerItem[]; // 두 형태 모두 지원하도록 변경
   finalCenterMarker?: LocationCentroid;
   centerMarker?: LocationCentroid;
+  memberMarkers?: {
+    latitude: number;
+    longitude: number;
+    imageUrl?: string;
+  }[];
   onMarkerClick?: (markerId: number) => void;
   polygon?: { lat: number; lng: number }[];
 }


### PR DESCRIPTION
## 🤔 문제 및 해결방안

- 페이지 새로고침 시 memberId 정보가 유실되어 위치 정보가 사라지는 문제가 발생했습니다. 
- 리더와 멤버를 구분하여 URL 파라미터에 정보 추가(리더: role=leader&memberId, 멤버: memberId만)

## ✍️ 구현 설명

- 리더의 경우: `?memberId={id}&role=leader` 형태로 파라미터 전달하여 리더 권한과 위치 정보 함께 유지
- 일반 멤버의 경우: `?memberId={id}` 형태로 전달하여 선택된 멤버 위치 표시
- 탠스택 쿼리 캐싱에만 의존하던 방식에서 URL 파라미터 기반 방식으로 변경하여 새로고침 내구성 확보
- 멤버별 위치 조회를 위한 /locations/ API 연동 및 마커 표시 로직 개선
- NaverMap 컴포넌트에 memberMarkers 속성 추가로 선택된 멤버 위치 구분 표시

### 📷 이미지 첨부 (Option)
1.리더가 방을 만든다.

https://github.com/user-attachments/assets/a514e305-64c0-4eea-8953-834a7b094e3b

2. 팔로워가 접속하여 위치 입력을 한다.

https://github.com/user-attachments/assets/4942f931-8c9f-4b31-ae2f-183491d4f69b

3. 마지막 팔로워 

https://github.com/user-attachments/assets/a4a296b4-facb-432e-ab79-681794af7018

4. 다른 사람 프로필 조회 -> 마커 확인


https://github.com/user-attachments/assets/847b4ea0-6356-4d7a-83e1-763349ef8344




### ⚠️ 유의할 점! (Option)

- 기존 라우팅 규칙은 유지한 채 쿼리 파라미터 방식만 적용되었습니다.
- 3/30 내 0명일 경우 분기처리 구현 예정입니다.

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
