### PR TITLE
fix(web): 출발지 등록시 시,도 주소는 제외하고 주소를 보내도록 수정

### DIFF
--- a/apps/web/src/api/types/locations/index.types.ts
+++ b/apps/web/src/api/types/locations/index.types.ts
@@ -5,7 +5,7 @@ export interface LocationsRequestProps {
   memberId: string;
   latitude: number;
   longitude: number;
-  name: string; // TODO소정 -> 준영 확인 필요!!! Address 추가로 인해 추가되었는데 확인 바람!!!
+  name: string;
 }
 
 export interface Locations {

--- a/apps/web/src/components/search-place-bottom-sheet/index.tsx
+++ b/apps/web/src/components/search-place-bottom-sheet/index.tsx
@@ -131,7 +131,10 @@ const SearchPlaceBottomSheet = ({
       memberId,
       latitude: Number(place.mapy),
       longitude: Number(place.mapx),
-      name: place.address,
+      name: place.address
+        .split(" ")
+        .filter((_, index) => index !== 0)
+        .join(" "),
     });
   };
 

--- a/apps/web/src/hooks/api/useCurrentLocation.ts
+++ b/apps/web/src/hooks/api/useCurrentLocation.ts
@@ -57,10 +57,6 @@ export const useCurrentLocation = () => {
       },
       (err) => {
         console.error(err.message);
-      },
-      {
-        enableHighAccuracy: true, // GPS 기반 정확한 위치 요청
-        maximumAge: 0, // 캐시된 위치 데이터 사용하지 않음
       }
     );
   };


### PR DESCRIPTION
<!-- 작성 예시 -->

<!-- # 문제 및 해결방안 -->
<!-- - 간략한 문제 설명 (문제 관련 링크 등등) -->
<!-- - 해당 문제를 해결한 방법에 대한 설명 -->

<!-- # 구현 설명 -->
<!-- - 동작 방식 등 코드적으로 구현한 방법에 대한 설명 -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 문제 및 해결방안

- 출발지 시, 도에 대한 주소는 제외하고 주소를 보내도록 수정하였습니다.
- 추가적으로 정확한 주소를 얻어오기 위한 옵션이 간헐적으로 에러를 발생시켜 삭제하였습니다.

## ✍️ 구현 설명

-

### 📷 이미지 첨부 (Option)

<img width="559" alt="스크린샷 2025-04-02 오후 2 57 12" src="https://github.com/user-attachments/assets/5b05b0cb-70ce-446d-848e-4e28ae1f1eb5" />

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
