### PR TITLE
refactor(ui, web): 지하철 노선 색상 관련 유틸 함수 통합 및 리팩토링

### DIFF
--- a/apps/web/src/components/add-location-modal/atoms/LineNumber.tsx
+++ b/apps/web/src/components/add-location-modal/atoms/LineNumber.tsx
@@ -1,5 +1,6 @@
 import { Flex, Text } from "@repo/ui/components";
 import * as styles from "../style.css";
+import { getLineColorName } from "@/utils/subway";
 
 export type LineNumberSizeType = "sm" | "md";
 
@@ -7,29 +8,6 @@ interface LineNumberProps {
   line: string;
   size?: LineNumberSizeType;
 }
-
-export const getLineColorName = (lineName: string): styles.SubwayColorProps => {
-  if (!isNaN(Number(lineName)))
-    return `line${lineName}` as styles.SubwayColorProps;
-
-  switch (lineName) {
-    case "신분당":
-      return "shinbundang";
-    case "공항":
-      return "gonghang";
-    case "경의중앙":
-      return "gyeonguiJungang";
-    case "분당":
-    case "수인":
-      return "suinbundang";
-    case "인천1":
-      return "incheon1";
-    case "인천2":
-      return "incheon2";
-  }
-
-  return "default";
-};
 
 const LineNumber = ({ line, size = "sm" }: LineNumberProps) => {
   const textVariant = size === "sm" ? "number" : "number-md";

--- a/apps/web/src/components/add-location-modal/atoms/LineNumber.tsx
+++ b/apps/web/src/components/add-location-modal/atoms/LineNumber.tsx
@@ -1,6 +1,6 @@
 import { Flex, Text } from "@repo/ui/components";
 import * as styles from "../style.css";
-import { getLineColorName } from "@/utils/subway";
+import { getSubwayColor } from "@/utils/subway";
 
 export type LineNumberSizeType = "sm" | "md";
 
@@ -11,6 +11,8 @@ interface LineNumberProps {
 
 const LineNumber = ({ line, size = "sm" }: LineNumberProps) => {
   const textVariant = size === "sm" ? "number" : "number-md";
+  const backgroundColor = getSubwayColor(line);
+
   return (
     <Flex
       key={line}
@@ -18,9 +20,9 @@ const LineNumber = ({ line, size = "sm" }: LineNumberProps) => {
       justify="center"
       align="center"
       className={styles.lineNumberRecipe({
-        subway: getLineColorName(line),
         size,
       })}
+      style={{ backgroundColor }}
     >
       <Text variant={textVariant}>{line}</Text>
     </Flex>

--- a/apps/web/src/components/add-location-modal/molecules/LineNumbers.tsx
+++ b/apps/web/src/components/add-location-modal/molecules/LineNumbers.tsx
@@ -1,14 +1,11 @@
 import { Flex } from "@repo/ui/components";
 import LineNumber, { type LineNumberSizeType } from "../atoms/LineNumber";
+import { removeLineSuffix } from "@/utils/subway";
 
 interface LineNumbersProps {
   lines: string[];
   size?: LineNumberSizeType;
 }
-
-export const removeLineSuffix = (line: string): string => {
-  return line.replace(/(선|호선|철도)$/, "");
-};
 
 const LineNumbers = ({ lines, size = "sm" }: LineNumbersProps) => {
   return (

--- a/apps/web/src/components/add-location-modal/molecules/StationBanner.tsx
+++ b/apps/web/src/components/add-location-modal/molecules/StationBanner.tsx
@@ -2,13 +2,13 @@ import { Flex, Text } from "@repo/ui/components";
 import { StationInfo } from "@/api/types/stations/index.type";
 import * as styles from "../style.css";
 import LineNumbers from "./LineNumbers";
-import { getLineColorName } from "../atoms/LineNumber";
-import { removeLineSuffix } from "@/utils/subway";
+import { getLineColorName, removeLineSuffix } from "@/utils/subway";
 
 type StationBannerProps = StationInfo;
 
 const StationBanner = ({ station, routes }: StationBannerProps) => {
   const lineColor = getLineColorName(removeLineSuffix(routes[0]!));
+
   return (
     <Flex justify="center" className={styles.bannerContainer}>
       <Flex

--- a/apps/web/src/components/add-location-modal/molecules/StationBanner.tsx
+++ b/apps/web/src/components/add-location-modal/molecules/StationBanner.tsx
@@ -2,12 +2,12 @@ import { Flex, Text } from "@repo/ui/components";
 import { StationInfo } from "@/api/types/stations/index.type";
 import * as styles from "../style.css";
 import LineNumbers from "./LineNumbers";
-import { getLineColorName, removeLineSuffix } from "@/utils/subway";
+import { getSubwayColor } from "@/utils/subway";
 
 type StationBannerProps = StationInfo;
 
 const StationBanner = ({ station, routes }: StationBannerProps) => {
-  const lineColor = getLineColorName(removeLineSuffix(routes[0]!));
+  const lineColor = getSubwayColor(routes[0]!);
 
   return (
     <Flex justify="center" className={styles.bannerContainer}>
@@ -15,13 +15,17 @@ const StationBanner = ({ station, routes }: StationBannerProps) => {
         align="center"
         justify="center"
         gap={12}
-        className={styles.bannerRecipe({ border: lineColor })}
+        className={styles.banner}
+        style={{ borderColor: lineColor }}
       >
         <LineNumbers lines={routes} size="md" />
         <Text variant="heading3">{station.name}</Text>
       </Flex>
 
-      <div className={styles.bannerLineRecipe({ border: lineColor })} />
+      <div
+        className={styles.bannerLine}
+        style={{ borderColor: lineColor, background: lineColor }}
+      />
     </Flex>
   );
 };

--- a/apps/web/src/components/add-location-modal/molecules/StationBanner.tsx
+++ b/apps/web/src/components/add-location-modal/molecules/StationBanner.tsx
@@ -1,8 +1,9 @@
 import { Flex, Text } from "@repo/ui/components";
 import { StationInfo } from "@/api/types/stations/index.type";
 import * as styles from "../style.css";
-import LineNumbers, { removeLineSuffix } from "./LineNumbers";
+import LineNumbers from "./LineNumbers";
 import { getLineColorName } from "../atoms/LineNumber";
+import { removeLineSuffix } from "@/utils/subway";
 
 type StationBannerProps = StationInfo;
 

--- a/apps/web/src/components/add-location-modal/style.css.ts
+++ b/apps/web/src/components/add-location-modal/style.css.ts
@@ -21,6 +21,7 @@ const subwayColors = {
   gyeonggang: theme.colors.subwayAdjustGyeongGang,
   everline: theme.colors.subwayAdjustEverLine,
   gimpoGold: theme.colors.subwayAdjustGimpoGold,
+  sillim: theme.colors.subwayAdjustSillim,
   gtx: theme.colors.subwayAdjustGTX,
   gonghang: theme.colors.subwayAdjustAirport,
   incheon1: theme.colors.subwayAdjustIncheon1,

--- a/apps/web/src/components/add-location-modal/style.css.ts
+++ b/apps/web/src/components/add-location-modal/style.css.ts
@@ -3,46 +3,6 @@ import { zIndex } from "@repo/z-index";
 import { style } from "@vanilla-extract/css";
 import { recipe } from "@vanilla-extract/recipes";
 
-export type SubwayColorProps = keyof typeof subwayBackgroundVariants;
-const subwayColors = {
-  line1: theme.colors.subwayAdjust1,
-  line2: theme.colors.subwayAdjust2,
-  line3: theme.colors.subwayAdjust3,
-  line4: theme.colors.subwayAdjust4,
-  line5: theme.colors.subwayAdjust5,
-  line6: theme.colors.subwayAdjust6,
-  line7: theme.colors.subwayAdjust7,
-  line8: theme.colors.subwayAdjust8,
-  line9: theme.colors.subwayAdjust9,
-  shinbundang: theme.colors.subwayAdjustShinbundang,
-  gyeonguiJungang: theme.colors.subwayAdjustGyeonguiJungang,
-  suinbundang: theme.colors.subwayAdjustSuinbundang,
-  uiSinseol: theme.colors.subwayAdjustUiSinseol,
-  gyeonggang: theme.colors.subwayAdjustGyeongGang,
-  everline: theme.colors.subwayAdjustEverLine,
-  gimpoGold: theme.colors.subwayAdjustGimpoGold,
-  sillim: theme.colors.subwayAdjustSillim,
-  gtx: theme.colors.subwayAdjustGTX,
-  gonghang: theme.colors.subwayAdjustAirport,
-  incheon1: theme.colors.subwayAdjustIncheon1,
-  incheon2: theme.colors.subwayAdjustIncheon2,
-  default: theme.colors.orange30,
-};
-
-export const subwayBackgroundVariants = Object.fromEntries(
-  Object.entries(subwayColors).map(([key, color]) => [
-    key,
-    { background: color },
-  ])
-);
-
-export const subwayBorderVariants = Object.fromEntries(
-  Object.entries(subwayColors).map(([key, color]) => [
-    key,
-    { borderColor: color },
-  ])
-);
-
 export const container = style({
   width: "100%",
   height: "100%",
@@ -90,7 +50,6 @@ export const lineNumberRecipe = recipe({
     color: "white",
   },
   variants: {
-    subway: subwayBackgroundVariants,
     size: {
       sm: {
         padding: "2px 6px",
@@ -105,7 +64,6 @@ export const lineNumberRecipe = recipe({
     },
   },
   defaultVariants: {
-    subway: "default",
     size: "sm",
   },
 });

--- a/apps/web/src/components/add-location-modal/style.css.ts
+++ b/apps/web/src/components/add-location-modal/style.css.ts
@@ -152,38 +152,22 @@ export const bannerContainer = style({
   marginTop: "25%",
 });
 
-export const bannerRecipe = recipe({
-  base: {
-    padding: "24px",
-    width: "fit-content",
-    borderRadius: "100px",
-    border: "10px solid",
-    zIndex: zIndex.floating + 5,
-    background: theme.colors.gray0,
-    flexWrap: "wrap",
-  },
-  variants: {
-    border: subwayBorderVariants,
-  },
-  defaultVariants: {
-    border: "default",
-  },
+export const banner = style({
+  padding: "24px",
+  width: "fit-content",
+  borderRadius: "100px",
+  border: "10px solid",
+  zIndex: zIndex.floating + 5,
+  background: theme.colors.gray0,
+  flexWrap: "wrap",
 });
 
-export const bannerLineRecipe = recipe({
-  base: {
-    position: "absolute",
-    top: "50%",
-    left: 0,
-    transform: "translateY(-50%)",
-    width: "100%",
-    borderTop: "24px solid",
-    borderBottom: "24px solid",
-  },
-  variants: {
-    border: subwayBorderVariants,
-  },
-  defaultVariants: {
-    border: "default",
-  },
+export const bannerLine = style({
+  position: "absolute",
+  top: "50%",
+  left: 0,
+  transform: "translateY(-50%)",
+  width: "100%",
+  borderTop: "24px solid",
+  borderBottom: "24px solid",
 });

--- a/apps/web/src/components/add-location-modal/style.css.ts
+++ b/apps/web/src/components/add-location-modal/style.css.ts
@@ -4,44 +4,43 @@ import { style } from "@vanilla-extract/css";
 import { recipe } from "@vanilla-extract/recipes";
 
 export type SubwayColorProps = keyof typeof subwayBackgroundVariants;
+const subwayColors = {
+  line1: theme.colors.subwayAdjust1,
+  line2: theme.colors.subwayAdjust2,
+  line3: theme.colors.subwayAdjust3,
+  line4: theme.colors.subwayAdjust4,
+  line5: theme.colors.subwayAdjust5,
+  line6: theme.colors.subwayAdjust6,
+  line7: theme.colors.subwayAdjust7,
+  line8: theme.colors.subwayAdjust8,
+  line9: theme.colors.subwayAdjust9,
+  shinbundang: theme.colors.subwayAdjustShinbundang,
+  gyeonguiJungang: theme.colors.subwayAdjustGyeonguiJungang,
+  suinbundang: theme.colors.subwayAdjustSuinbundang,
+  uiSinseol: theme.colors.subwayAdjustUiSinseol,
+  gyeonggang: theme.colors.subwayAdjustGyeongGang,
+  everline: theme.colors.subwayAdjustEverLine,
+  gimpoGold: theme.colors.subwayAdjustGimpoGold,
+  gtx: theme.colors.subwayAdjustGTX,
+  gonghang: theme.colors.subwayAdjustAirport,
+  incheon1: theme.colors.subwayAdjustIncheon1,
+  incheon2: theme.colors.subwayAdjustIncheon2,
+  default: theme.colors.orange30,
+};
 
-const subwayBackgroundVariants = {
-  line1: { background: theme.colors.subwayAdjust1 },
-  line2: { background: theme.colors.subwayAdjust2 },
-  line3: { background: theme.colors.subwayAdjust3 },
-  line4: { background: theme.colors.subwayAdjust4 },
-  line5: { background: theme.colors.subwayAdjust5 },
-  line6: { background: theme.colors.subwayAdjust6 },
-  line7: { background: theme.colors.subwayAdjust7 },
-  line8: { background: theme.colors.subwayAdjust8 },
-  line9: { background: theme.colors.subwayAdjust9 },
-  shinbundang: { background: theme.colors.subwayAdjustShinbundang },
-  gyeonguiJungang: { background: theme.colors.subwayAdjustGyeonguiJungang },
-  suinbundang: { background: theme.colors.subwayAdjustSuinbundang },
-  gonghang: { background: theme.colors.subwayAdjustAirport },
-  incheon1: { background: theme.colors.subwayAdjustIncheon1 },
-  incheon2: { background: theme.colors.subwayAdjustIncheon2 },
-  default: { background: theme.colors.orange30 },
-} as const;
+export const subwayBackgroundVariants = Object.fromEntries(
+  Object.entries(subwayColors).map(([key, color]) => [
+    key,
+    { background: color },
+  ])
+);
 
-const subwayBorderVariants = {
-  line1: { borderColor: theme.colors.subwayAdjust1 },
-  line2: { borderColor: theme.colors.subwayAdjust2 },
-  line3: { borderColor: theme.colors.subwayAdjust3 },
-  line4: { borderColor: theme.colors.subwayAdjust4 },
-  line5: { borderColor: theme.colors.subwayAdjust5 },
-  line6: { borderColor: theme.colors.subwayAdjust6 },
-  line7: { borderColor: theme.colors.subwayAdjust7 },
-  line8: { borderColor: theme.colors.subwayAdjust8 },
-  line9: { borderColor: theme.colors.subwayAdjust9 },
-  shinbundang: { borderColor: theme.colors.subwayAdjustShinbundang },
-  gyeonguiJungang: { borderColor: theme.colors.subwayAdjustGyeonguiJungang },
-  suinbundang: { borderColor: theme.colors.subwayAdjustSuinbundang },
-  gonghang: { borderColor: theme.colors.subwayAdjustAirport },
-  incheon1: { borderColor: theme.colors.subwayAdjustIncheon1 },
-  incheon2: { borderColor: theme.colors.subwayAdjustIncheon2 },
-  default: { borderColor: theme.colors.orange30 },
-} as const;
+export const subwayBorderVariants = Object.fromEntries(
+  Object.entries(subwayColors).map(([key, color]) => [
+    key,
+    { borderColor: color },
+  ])
+);
 
 export const container = style({
   width: "100%",

--- a/apps/web/src/components/midpoint-result/organisms/ResultBottomSheet.tsx
+++ b/apps/web/src/components/midpoint-result/organisms/ResultBottomSheet.tsx
@@ -7,7 +7,6 @@ import * as styles from "./styles.css";
 import { secondsToTime } from "@/utils/time";
 import { metersToKilometersString } from "@/utils/meterToKilometers";
 import TransportBar from "./TransporBar";
-import { parseSubwayLineNumber } from "@/utils/subway";
 import { ReactNode } from "react";
 import KakaoTalkShareButton from "@/components/share-room/molecule/KakaoTalkShareButton";
 import { KAKAO_TEMPLATE_IDS } from "@/constants/kakao-template";
@@ -98,7 +97,6 @@ const ResultBottomSheet = ({
                   key={index}
                   width={widthPercentage}
                   time={Math.round(leg.sectionTime / 60)}
-                  lineNum={parseSubwayLineNumber(leg.route)}
                   isSubway={true}
                   color={
                     leg.routeColor ? `#${leg.routeColor}` : theme.colors.gray40
@@ -113,7 +111,6 @@ const ResultBottomSheet = ({
                   key={index}
                   width={widthPercentage}
                   time={Math.round(leg.sectionTime / 60)}
-                  lineNum={0}
                   isSubway={false}
                   color={theme.colors.gray50}
                   route={leg.route || undefined}
@@ -127,7 +124,6 @@ const ResultBottomSheet = ({
                   key={index}
                   width={widthPercentage}
                   time={Math.round(leg.sectionTime / 60)}
-                  lineNum={0}
                   isSubway={false}
                   color={theme.colors.gray15}
                   route="WALK"

--- a/apps/web/src/components/midpoint-result/organisms/TransporBar.tsx
+++ b/apps/web/src/components/midpoint-result/organisms/TransporBar.tsx
@@ -23,7 +23,6 @@ import {
 interface TransportBarProps {
   width: number;
   time: number;
-  lineNum: number | string;
   isSubway: boolean;
   color?: string;
   route?: string;
@@ -33,7 +32,6 @@ interface TransportBarProps {
 const TransportBar = ({
   width,
   time,
-  lineNum,
   isSubway,
   color,
   route,

--- a/apps/web/src/components/midpoint-result/organisms/TransporBar.tsx
+++ b/apps/web/src/components/midpoint-result/organisms/TransporBar.tsx
@@ -56,23 +56,23 @@ const TransportBar = ({
     const lineType = identifySubwayLine(route);
 
     switch (lineType) {
-      case 1:
+      case "1":
         return <Line1 />;
-      case 2:
+      case "2":
         return <Line2 />;
-      case 3:
+      case "3":
         return <Line3 />;
-      case 4:
+      case "4":
         return <Line4 />;
-      case 5:
+      case "5":
         return <Line5 />;
-      case 6:
+      case "6":
         return <Line6 />;
-      case 7:
+      case "7":
         return <Line7 />;
-      case 8:
+      case "8":
         return <Line8 />;
-      case 9:
+      case "9":
         return <Line9 />;
       case "신분당":
         return <LineShinBundang />;

--- a/apps/web/src/constants/subway/index.ts
+++ b/apps/web/src/constants/subway/index.ts
@@ -1,22 +1,6 @@
 import { theme } from "@repo/ui/tokens";
 
-export type SubwayLineType =
-  | 1
-  | 2
-  | 3
-  | 4
-  | 5
-  | 6
-  | 7
-  | 8
-  | 9
-  | "신분당"
-  | "수인분당"
-  | "경의중앙"
-  | "인천1"
-  | "인천2"
-  | "공항철도"
-  | "unknown";
+export type SubwayLineType = keyof typeof SUBWAY_META;
 
 export const SUBWAY_META = {
   1: {

--- a/apps/web/src/constants/subway/index.ts
+++ b/apps/web/src/constants/subway/index.ts
@@ -1,53 +1,58 @@
 import { theme } from "@repo/ui/tokens";
 
-export type SubwayLineType = keyof typeof SUBWAY_META;
+export type NormalLineType = keyof typeof NORMAL_LINES;
+export type SpecialLineType = keyof typeof SPECIAL_LINES;
+export type SubwayLineType = NormalLineType | SpecialLineType;
 
-export const SUBWAY_META = {
-  1: {
+export const NORMAL_LINES = {
+  "1": {
     name: "1호선",
     color: theme.colors.subwayAdjust1,
     pattern: /1호선|수도권1/,
   },
-  2: {
+  "2": {
     name: "2호선",
     color: theme.colors.subwayAdjust2,
     pattern: /2호선|수도권2/,
   },
-  3: {
+  "3": {
     name: "3호선",
     color: theme.colors.subwayAdjust3,
     pattern: /3호선|수도권3/,
   },
-  4: {
+  "4": {
     name: "4호선",
     color: theme.colors.subwayAdjust4,
     pattern: /4호선|수도권4/,
   },
-  5: {
+  "5": {
     name: "5호선",
     color: theme.colors.subwayAdjust5,
     pattern: /5호선|수도권5/,
   },
-  6: {
+  "6": {
     name: "6호선",
     color: theme.colors.subwayAdjust6,
     pattern: /6호선|수도권6/,
   },
-  7: {
+  "7": {
     name: "7호선",
     color: theme.colors.subwayAdjust7,
     pattern: /7호선|수도권7/,
   },
-  8: {
+  "8": {
     name: "8호선",
     color: theme.colors.subwayAdjust8,
     pattern: /8호선|수도권8/,
   },
-  9: {
+  "9": {
     name: "9호선",
     color: theme.colors.subwayAdjust9,
     pattern: /9호선|수도권9/,
   },
+};
+
+export const SPECIAL_LINES = {
   신분당: {
     name: "신분당선",
     color: theme.colors.subwayAdjustShinbundang,
@@ -75,12 +80,47 @@ export const SUBWAY_META = {
   },
   공항철도: {
     name: "공항철도",
-    color: "#0065B3",
-    pattern: /공항철도|공항철도1/,
+    color: theme.colors.subwayAdjustAirport,
+    pattern: /공항철도/,
+  },
+  우이신설: {
+    name: "우이신설선",
+    color: theme.colors.subwayAdjustUiSinseol,
+    pattern: /우이신설/,
+  },
+  김포골드: {
+    name: "김포골드라인",
+    color: theme.colors.subwayAdjustGimpoGold,
+    pattern: /김포골드/,
+  },
+  경강: {
+    name: "경강선",
+    color: theme.colors.subwayAdjustGyeongGang,
+    pattern: /경강/,
+  },
+  에버라인: {
+    name: "에버라인",
+    color: theme.colors.subwayAdjustEverLine,
+    pattern: /에버라인/,
+  },
+  신림: {
+    name: "신림선",
+    color: theme.colors.subwayAdjustSillim,
+    pattern: /신림/,
+  },
+  GTX: {
+    name: "GTX",
+    color: theme.colors.subwayAdjustGTX,
+    pattern: /GTX/i,
   },
   unknown: {
     name: "알 수 없음",
     color: theme.colors.gray40,
     pattern: /.*/,
   },
+};
+
+export const SUBWAY_META = {
+  ...NORMAL_LINES,
+  ...SPECIAL_LINES,
 };

--- a/apps/web/src/utils/subway.ts
+++ b/apps/web/src/utils/subway.ts
@@ -16,9 +16,18 @@ export const getLineColorName = (lineName: string): SubwayColorProps => {
       return "gonghang";
     case "경의중앙":
       return "gyeonguiJungang";
-    case "분당":
-    case "수인":
+    case "수인분당":
       return "suinbundang";
+    case "우이신설":
+      return "uiSinseol";
+    case "경강":
+      return "gyeonggang";
+    case "에버라인":
+      return "everline";
+    case "김포골드":
+      return "gimpoGold";
+    case "GTX":
+      return "gtx";
     case "인천1":
       return "incheon1";
     case "인천2":

--- a/apps/web/src/utils/subway.ts
+++ b/apps/web/src/utils/subway.ts
@@ -1,40 +1,14 @@
+import { NormalLineType } from "./../constants/subway/index";
 import { theme } from "@repo/ui/tokens";
-import { SUBWAY_META, SubwayLineType } from "../constants/subway";
-import { SubwayColorProps } from "@/components/add-location-modal/style.css";
+import {
+  SPECIAL_LINES,
+  SpecialLineType,
+  SUBWAY_META,
+  SubwayLineType,
+} from "../constants/subway";
 
 export const removeLineSuffix = (line: string): string => {
   return line.replace(/(선|호선)$/, "");
-};
-
-export const getLineColorName = (lineName: string): SubwayColorProps => {
-  if (!isNaN(Number(lineName))) return `line${lineName}` as SubwayColorProps;
-
-  switch (lineName) {
-    case "신분당":
-      return "shinbundang";
-    case "공항철도":
-      return "gonghang";
-    case "경의중앙":
-      return "gyeonguiJungang";
-    case "수인분당":
-      return "suinbundang";
-    case "우이신설":
-      return "uiSinseol";
-    case "경강":
-      return "gyeonggang";
-    case "에버라인":
-      return "everline";
-    case "김포골드":
-      return "gimpoGold";
-    case "GTX":
-      return "gtx";
-    case "인천1":
-      return "incheon1";
-    case "인천2":
-      return "incheon2";
-  }
-
-  return "default";
 };
 
 export const parseSubwayLineNumber = (route: string | null): number => {
@@ -46,23 +20,18 @@ export const parseSubwayLineNumber = (route: string | null): number => {
 export const identifySubwayLine = (route: string | null): SubwayLineType => {
   if (!route) return "unknown";
 
-  const specialLines = [
-    "신분당",
-    "수인분당",
-    "경의중앙",
-    "인천1",
-    "인천2",
-    "공항철도",
-  ] as const;
-  for (const line of specialLines) {
-    if (SUBWAY_META[line].pattern.test(route)) {
-      return line;
-    }
+  // NOTE: 숫자 노선 처리
+  if (!isNaN(Number(route))) {
+    return route as NormalLineType;
   }
 
-  const lineNumber = parseSubwayLineNumber(route);
-  if (lineNumber >= 1 && lineNumber <= 9) {
-    return lineNumber as SubwayLineType;
+  // NOTE: 특수 노선 처리
+  const specialLines = Object.keys(SPECIAL_LINES) as SpecialLineType[];
+
+  for (const line of specialLines) {
+    if (SPECIAL_LINES[line].pattern.test(route)) {
+      return line;
+    }
   }
 
   return "unknown";

--- a/apps/web/src/utils/subway.ts
+++ b/apps/web/src/utils/subway.ts
@@ -3,7 +3,7 @@ import { SUBWAY_META, SubwayLineType } from "../constants/subway";
 import { SubwayColorProps } from "@/components/add-location-modal/style.css";
 
 export const removeLineSuffix = (line: string): string => {
-  return line.replace(/(선|호선|철도)$/, "");
+  return line.replace(/(선|호선)$/, "");
 };
 
 export const getLineColorName = (lineName: string): SubwayColorProps => {
@@ -12,7 +12,7 @@ export const getLineColorName = (lineName: string): SubwayColorProps => {
   switch (lineName) {
     case "신분당":
       return "shinbundang";
-    case "공항":
+    case "공항철도":
       return "gonghang";
     case "경의중앙":
       return "gyeonguiJungang";

--- a/apps/web/src/utils/subway.ts
+++ b/apps/web/src/utils/subway.ts
@@ -1,6 +1,10 @@
 import { theme } from "@repo/ui/tokens";
 import { SUBWAY_META, SubwayLineType } from "../constants/subway";
 
+export const removeLineSuffix = (line: string): string => {
+  return line.replace(/(선|호선|철도)$/, "");
+};
+
 export const parseSubwayLineNumber = (route: string | null): number => {
   if (!route) return 0;
   const matches = route.match(/\d+/);

--- a/apps/web/src/utils/subway.ts
+++ b/apps/web/src/utils/subway.ts
@@ -1,8 +1,31 @@
 import { theme } from "@repo/ui/tokens";
 import { SUBWAY_META, SubwayLineType } from "../constants/subway";
+import { SubwayColorProps } from "@/components/add-location-modal/style.css";
 
 export const removeLineSuffix = (line: string): string => {
   return line.replace(/(선|호선|철도)$/, "");
+};
+
+export const getLineColorName = (lineName: string): SubwayColorProps => {
+  if (!isNaN(Number(lineName))) return `line${lineName}` as SubwayColorProps;
+
+  switch (lineName) {
+    case "신분당":
+      return "shinbundang";
+    case "공항":
+      return "gonghang";
+    case "경의중앙":
+      return "gyeonguiJungang";
+    case "분당":
+    case "수인":
+      return "suinbundang";
+    case "인천1":
+      return "incheon1";
+    case "인천2":
+      return "incheon2";
+  }
+
+  return "default";
 };
 
 export const parseSubwayLineNumber = (route: string | null): number => {

--- a/apps/web/src/utils/subway.ts
+++ b/apps/web/src/utils/subway.ts
@@ -70,6 +70,8 @@ export const identifySubwayLine = (route: string | null): SubwayLineType => {
 
 export const getSubwayColor = (route: string | null): string => {
   if (!route) return theme.colors.gray40;
-  const lineType = identifySubwayLine(route);
+
+  const lineName = removeLineSuffix(route);
+  const lineType = identifySubwayLine(lineName);
   return SUBWAY_META[lineType].color;
 };

--- a/packages/ui/src/components/flex/index.tsx
+++ b/packages/ui/src/components/flex/index.tsx
@@ -27,13 +27,13 @@ export const Flex = ({
 }: PropsWithChildren<FlexProps>) => {
   return (
     <Tag
+      {...props}
       ref={ref}
       style={{ gap }}
       className={classMerge(
         flexRecipe({ justify, align, direction }),
         className
       )}
-      {...props}
     >
       {children}
     </Tag>

--- a/packages/ui/src/components/flex/index.tsx
+++ b/packages/ui/src/components/flex/index.tsx
@@ -23,13 +23,14 @@ export const Flex = ({
   children,
   className,
   ref,
+  style,
   ...props
 }: PropsWithChildren<FlexProps>) => {
   return (
     <Tag
       {...props}
       ref={ref}
-      style={{ gap }}
+      style={{ gap, ...style }}
       className={classMerge(
         flexRecipe({ justify, align, direction }),
         className

--- a/packages/ui/src/tokens/colors.ts
+++ b/packages/ui/src/tokens/colors.ts
@@ -108,6 +108,7 @@ const scale = {
   subwayAdjustGyeongGang: "#1F5FCB",
   subwayAdjustEverLine: "#7CC250",
   subwayAdjustGimpoGold: "#C28B3E",
+  subwayAdjustSillim: "#6789CA",
   subwayAdjustGTX: "#B072A7",
 
   mapPolygon: "rgba(27, 32, 44, 0.1)",

--- a/packages/ui/src/tokens/colors.ts
+++ b/packages/ui/src/tokens/colors.ts
@@ -104,10 +104,22 @@ const scale = {
   subwayAdjustIncheon1: "#7EA5CD",
   subwayAdjustIncheon2: "#F7931D",
   subwayAdjustAirport: "#1589BC",
+  subwayAdjustUiSinseol: "#BAC94C",
+  subwayAdjustGyeongGang: "#1F5FCB",
+  subwayAdjustEverLine: "#7CC250",
+  subwayAdjustGimpoGold: "#C28B3E",
+  subwayAdjustGTX: "#B072A7",
 
   mapPolygon: "rgba(27, 32, 44, 0.1)",
   mapMarkerBorder: "#000000",
 };
+
+/*
+TODO: 추후 GTX-A,B,C 구분
+  GTX A: B072A7
+  GTX B: 2F57B7
+  GTX C: 357965
+*/
 
 const token = {
   textPrimary: scale.gray95,

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
+    "rootDir": ".",
     "outDir": "dist"
   },
   "include": ["src"],


### PR DESCRIPTION
<!-- 작성 예시 -->

<!-- # 문제 및 해결방안 -->
<!-- - 간략한 문제 설명 (문제 관련 링크 등등) -->
<!-- - 해당 문제를 해결한 방법에 대한 설명 -->

<!-- # 구현 설명 -->
<!-- - 동작 방식 등 코드적으로 구현한 방법에 대한 설명 -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 문제 및 해결방안

- 노선 이름에 따라 색상을 받아오는 유틸 함수가 로직은 같지만 분리되어 재사용되지 않고 있었습니다.
- Flex에서 gap 속성을 style이 덮어 적용되지 않았습니다.
- packages 폴더에서 rootDir 설정 관련 빨간줄이 지속되어 수정하였습니다.

## ✍️ 구현 설명

- 신규 노선에 대한 색상들을 추가하였습니다.
- 후보지 추가 로직에서 사용되는 지하철 노선 색상 함수들과 결과 화면 로직에 사용되는 색상을 통합하였습니다.
  - type과 상수 정의를 통해 코드 재사용성을 높혔습니다.
- 지하철 노선 객체를 일반 노선과 특수 객체로 나누어 병합하였습니다.
  - 타입도 마찬가지로 객체들에서 추출하여 병합하였습니다.
- Flex에서 style을 추가할 경우, 스프레드 연산자를 통해 모두 적용될 수 있도록 수정하였습니다.

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
