### PR TITLE
feat(web): 출발지 입력이 끝난 후, 멤버 온보딩 화면 접근시 투표 온보딩으로 자동 라우팅

### DIFF
--- a/apps/web/src/components/member-onboarding/index.tsx
+++ b/apps/web/src/components/member-onboarding/index.tsx
@@ -4,27 +4,20 @@ import { Button, Flex, LoadingDots, Text } from "@repo/ui/components";
 import Image from "next/image";
 import * as Style from "./style.css";
 import { useRoomInfo } from "@/hooks/api/useRoomInfo";
-import { useRouter } from "next/navigation";
-import { usePressEffect } from "@repo/motion";
+import Link from "next/link";
 
 interface MemberOnboardingProps {
   roomId: string;
 }
 
 const MemberOnboarding = ({ roomId }: MemberOnboardingProps) => {
-  const router = useRouter();
   const { data } = useRoomInfo(roomId);
-  const { backgroundRef, containerRef, pressProps } = usePressEffect();
 
   const descriptions = [
     "내 프로필을 만들고 출발지를 입력해요",
     "중간장소 후보를 확인하고 추가해요",
     "투표 안한 친구 들을 독촉해요",
   ];
-
-  const handleClickJoin = () => {
-    router.push(`/room/${roomId}/select-profile`);
-  };
 
   return (
     <Flex
@@ -67,17 +60,12 @@ const MemberOnboarding = ({ roomId }: MemberOnboardingProps) => {
         </Flex>
       </Flex>
 
-      <div className={Style.buttonContainer}>
-        <Button
-          variant="secondary"
-          ref={containerRef}
-          {...pressProps}
-          onClick={handleClickJoin}
-        >
-          <div ref={backgroundRef} className={Style.buttonBackground} />
+      <Button variant="secondary" className={Style.buttonContainer}>
+        <Link href={`/room/${roomId}/select-profile`}>
+          <div className={Style.buttonBackground} />
           약속방 참여하기
-        </Button>
-      </div>
+        </Link>
+      </Button>
     </Flex>
   );
 };

--- a/apps/web/src/components/member-onboarding/index.tsx
+++ b/apps/web/src/components/member-onboarding/index.tsx
@@ -1,18 +1,16 @@
 "use client";
 
-import { Button, Flex, LoadingDots, Text } from "@repo/ui/components";
+import { Button, Flex, Text } from "@repo/ui/components";
 import Image from "next/image";
 import * as Style from "./style.css";
-import { useRoomInfo } from "@/hooks/api/useRoomInfo";
 import Link from "next/link";
 
 interface MemberOnboardingProps {
   roomId: string;
+  roomName: string;
 }
 
-const MemberOnboarding = ({ roomId }: MemberOnboardingProps) => {
-  const { data } = useRoomInfo(roomId);
-
+const MemberOnboarding = ({ roomId, roomName }: MemberOnboardingProps) => {
   const descriptions = [
     "내 프로필을 만들고 출발지를 입력해요",
     "중간장소 후보를 확인하고 추가해요",
@@ -29,7 +27,7 @@ const MemberOnboarding = ({ roomId }: MemberOnboardingProps) => {
       <Flex direction="column" align="center" justify="between" gap={80}>
         <div className={Style.header}>
           <Text variant="title3" className={Style.speachBubble}>
-            {data ? data.data.roomName : <LoadingDots />}
+            {roomName}
             <div className={Style.speachBubbleTail} />
           </Text>
           <Text variant="heading3">모임 초대장이 도착했어요</Text>


### PR DESCRIPTION
<!-- 작성 예시 -->

<!-- # 문제 및 해결방안 -->
<!-- - 간략한 문제 설명 (문제 관련 링크 등등) -->
<!-- - 해당 문제를 해결한 방법에 대한 설명 -->

<!-- # 구현 설명 -->
<!-- - 동작 방식 등 코드적으로 구현한 방법에 대한 설명 -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 문제 및 해결방안

-

## ✍️ 구현 설명

- next 서버 단에서 방 정보를 요청한 후, 응답값의 roomStatus를 확인하여 next/navigation의 redirect 함수를 통해 라우팅을 적용하였습니다.

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
