### PR TITLE
fix: 터치시 motion api 사용하도록 변경

### DIFF
--- a/packages/ui/src/components/button/index.tsx
+++ b/packages/ui/src/components/button/index.tsx
@@ -1,16 +1,14 @@
-import { mergeProps } from "react-aria";
-import { ButtonHTMLAttributes, PropsWithChildren, RefObject } from "react";
+import { ComponentProps, PropsWithChildren, RefObject } from "react";
 import {
   buttonContainerStyle,
   buttonReceipe,
   ButtonVariants,
 } from "./style.css";
 import { classMerge } from "../../utils";
-import { motion, usePressEffect } from "@repo/motion";
-import mergeRefs from "merge-refs";
+import { motion } from "@repo/motion";
 import { theme } from "../../tokens";
 
-export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
+export type ButtonProps = ComponentProps<typeof motion.button> &
   ButtonVariants & { ref?: RefObject<HTMLButtonElement | null> };
 
 export const Button = ({
@@ -22,8 +20,6 @@ export const Button = ({
   children,
   ...props
 }: PropsWithChildren<ButtonProps>) => {
-  const { containerRef, pressProps } = usePressEffect();
-
   return (
     <motion.div
       className={classMerge(
@@ -31,12 +27,15 @@ export const Button = ({
         className
       )}
       variants={{
+        touch: {
+          scale: 0.96,
+        },
         wiggle: {
           x: [4, -4, 4, -4, 4, -4, 4, -4],
         },
       }}
       transition={{ duration: 3 }}
-      whileTap={props.disabled ? "wiggle" : ""}
+      whileTap={props.disabled ? "wiggle" : "touch"}
     >
       <motion.button
         animate={
@@ -51,8 +50,8 @@ export const Button = ({
           width,
           padding,
         })}
-        ref={mergeRefs(ref, containerRef)}
-        {...mergeProps(props, props.disabled ? {} : pressProps)}
+        ref={ref}
+        {...props}
       >
         {children}
       </motion.button>

--- a/packages/ui/src/components/button/index.tsx
+++ b/packages/ui/src/components/button/index.tsx
@@ -32,9 +32,9 @@ export const Button = ({
         },
         wiggle: {
           x: [4, -4, 4, -4, 4, -4, 4, -4],
+          transition: { duration: 3 },
         },
       }}
-      transition={{ duration: 3 }}
       whileTap={props.disabled ? "wiggle" : "touch"}
     >
       <motion.button


### PR DESCRIPTION
<!-- 작성 예시 -->

<!-- # 문제 및 해결방안 -->
<!-- - 간략한 문제 설명 (문제 관련 링크 등등) -->
<!-- - 해당 문제를 해결한 방법에 대한 설명 -->

<!-- # 구현 설명 -->
<!-- - 동작 방식 등 코드적으로 구현한 방법에 대한 설명 -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 문제 및 해결방안

- 커스텀 이벤트 대신 motion의 api를 사용하도록 변경합니다

## ✍️ 구현 설명

-

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
