### PR TITLE
fix: map zoom 최대

### DIFF
--- a/packages/naver-map/src/NaverMap.tsx
+++ b/packages/naver-map/src/NaverMap.tsx
@@ -12,7 +12,7 @@ import { ProfileMarker } from "./overlays/profile-marker";
 export const NAVER_MAP_CONFIG = {
   ZOOM_LEVEL: 17,
   MIN_ZOOM: 11,
-  MAX_ZOOM: 17,
+  MAX_ZOOM: 21,
   SCALE_FACTOR: 0.3,
   SEOUL_CENTER: { lat: 37.5665, lng: 126.978 },
   SEOUL_BOUNDS: {


### PR DESCRIPTION


## 🤔 문제 및 해결방안

- 네이버 지도 map zoom 최대인 21로 설정하였습니다.

## ✍️ 구현 설명

-

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
