### PR TITLE
fix(naver-map, web): 프로필 마커 하단이 제대로 나오지 않는 현상 수정

### DIFF
--- a/apps/web/src/components/midpoint-result/organisms/ResultBanner.tsx
+++ b/apps/web/src/components/midpoint-result/organisms/ResultBanner.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { DeleteIcon, SmallMidIcon } from "@repo/ui/icons";
 import { Text, Flex } from "@repo/ui/components";
 import * as styles from "./styles.css";

--- a/packages/naver-map/src/overlays/marker/profile-marker/ProfileMarker.tsx
+++ b/packages/naver-map/src/overlays/marker/profile-marker/ProfileMarker.tsx
@@ -14,14 +14,14 @@ export const ProfileMarker = ({
   const markerElement = document.createElement("div");
   markerElement.innerHTML = `
     <div style="position: relative;">
-      <div style="position: block; width: 48px; height: 48px; border-radius: 50%; overflow: hidden; border: 3px solid ${theme.colors.navy};">
+      <div style="position: inherit; width: 48px; height: 48px; border-radius: 50%; overflow: hidden; background-color: ${theme.colors.navy}; border: 3px solid ${theme.colors.navy}; z-index: 5">
         <img
           src="${profileImageUrl}"
           alt="profile image"
           style="width: 48px; height: 48px;"
         />
       </div>
-      <div style="position: absolute; left: 50%; bottom: -2px; border-radius: 2px; width: 16px; height: 16px; background-color: ${theme.colors.navy}; transform: translateX(-50%) rotate(45deg); z-index: -1;"></div>
+      <div style="position: absolute; left: 50%; bottom: -2px; border-radius: 2px; width: 16px; height: 16px; background-color: ${theme.colors.navy}; transform: translateX(-50%) rotate(45deg); z-index: 4;"></div>
     </div>
   `;
   return markerElement;


### PR DESCRIPTION
<!-- 작성 예시 -->

<!-- # 문제 및 해결방안 -->
<!-- - 간략한 문제 설명 (문제 관련 링크 등등) -->
<!-- - 해당 문제를 해결한 방법에 대한 설명 -->

<!-- # 구현 설명 -->
<!-- - 동작 방식 등 코드적으로 구현한 방법에 대한 설명 -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 문제 및 해결방안

- 모바일 환경에서 네이버 지도의 프로필 마커가 제대로 그려지지 않는 현상이 발생했습니다. (프로필 포커스)

## ✍️ 구현 설명

- position을 상속 받아 z-index가 정상적으로 동작하도록 수정하였습니다.

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
