### PR TITLE
feat: 주변 장소 검색 api 연동

### DIFF
--- a/apps/web/src/components/vote-voting/organism/CardItem.tsx
+++ b/apps/web/src/components/vote-voting/organism/CardItem.tsx
@@ -9,12 +9,14 @@ import { useState } from "react";
 import { StationMapExplorer } from "./StationMapExplorer";
 import { useCandidateStation } from "@/hooks/api/useCandidateStation";
 import { useParams } from "next/navigation";
+import { CandidateStationData } from "@/hooks/api/useCandidateStation";
 
 interface Props extends Candidate {
   view: "card" | "list";
   className: string;
   selected: boolean;
   onSelectCard: ({ id, name }: { id: number; name: string }) => void;
+  stationLocations: CandidateStationData;
 }
 
 export function CardItem({
@@ -27,13 +29,9 @@ export function CardItem({
   stationName,
   selected,
   onSelectCard,
+  stationLocations,
 }: Props) {
-  const params = useParams();
   const [showFullScreenMap, setShowFullScreenMap] = useState(false);
-  const { data: candidateStation } = useCandidateStation(
-    params?.roomId as string
-  );
-  const stationLocation = candidateStation?.data;
 
   const handleMapOpen = (e: any) => {
     e.stopPropagation();
@@ -41,7 +39,7 @@ export function CardItem({
   };
 
   const getStationLocation = (stationId: number) => {
-    const station = stationLocation?.find(
+    const station = stationLocations?.find(
       (station) => station.station.id === stationId
     );
 

--- a/apps/web/src/components/vote-voting/organism/CardList.tsx
+++ b/apps/web/src/components/vote-voting/organism/CardList.tsx
@@ -5,11 +5,13 @@ import { CardItem } from "./CardItem";
 import { useViewTransform } from "./useViewTransform";
 import { RowCardList } from "./RowCardList";
 import { Candidate } from "../templates/type";
+import { CandidateStationData } from "@/hooks/api/useCandidateStation";
 
 interface Props {
   view: "card" | "list";
   list: Candidate[];
   selectedCardIds: number[];
+  stationLocations: CandidateStationData;
   onIndexChange: (index: number) => void;
   onSelectCard: ({ id, name }: { id: number; name: string }) => void;
 }
@@ -18,6 +20,7 @@ export function CardList({
   view,
   list,
   selectedCardIds,
+  stationLocations,
   onIndexChange,
   onSelectCard,
 }: Props) {
@@ -52,6 +55,7 @@ export function CardList({
               view={view}
               className="card-0"
               selected={selectedCardIds.includes(first.stationId)}
+              stationLocations={stationLocations}
               {...first}
             />
           )}
@@ -62,6 +66,7 @@ export function CardList({
               key={index}
               className={`card-${index + 1}`}
               selected={selectedCardIds.includes(place.stationId)}
+              stationLocations={stationLocations}
               {...place}
             />
           ))}
@@ -71,6 +76,7 @@ export function CardList({
               view={view}
               className={`card-${list.length + 1}`}
               selected={selectedCardIds.includes(last.stationId)}
+              stationLocations={stationLocations}
               {...last}
             />
           )}

--- a/apps/web/src/components/vote-voting/organism/StationMapExplorer.tsx
+++ b/apps/web/src/components/vote-voting/organism/StationMapExplorer.tsx
@@ -3,51 +3,119 @@ import { createPortal } from "react-dom";
 import MapHeader from "@/components/midpoint-result/organisms/MapHeader";
 import { AnimationBottomSheet, Text } from "@repo/ui/components";
 import * as Style from "./StationMapExplorer.css";
-import { useState } from "react";
-import { FILTER_OPTIONS } from "@/constants/filter-options";
+import { useState, useEffect } from "react";
+import { FILTER_OPTIONS, PlaceType } from "@/constants/filter-options";
+import { useNaverMap, useMarker, getFinalMarkerElement } from "@repo/naver-map";
+import { useSearchPlacesByFilter } from "@/hooks/useSearchPlacesByFilter";
+import { createPlaceMarkers } from "@/utils/createPlaceMarkers";
 
 interface StationMapExplorerProps {
   setShowFullScreenMap: (value: boolean) => void;
+  stationLocation: { latitude: number; longitude: number };
+  stationName: string;
 }
 
 export const StationMapExplorer = ({
   setShowFullScreenMap,
+  stationLocation,
+  stationName,
 }: StationMapExplorerProps) => {
   const handleMapClose = (e?: MouseEvent | TouchEvent) => {
     if (e) e.stopPropagation();
     setShowFullScreenMap(false);
   };
 
-  const [selectedFilter, setSelectedFilter] = useState<string | null>(null);
+  const [selectedFilter, setSelectedFilter] = useState<PlaceType | null>(
+    PlaceType.ACTIVITY
+  );
 
-  const subway = "망원";
+  const { map } = useNaverMap();
+  const stationMarker = useMarker({ map: map! });
+  const placesMarkers = useMarker({ map: map! });
 
-  const filterOptions = FILTER_OPTIONS;
+  const { places, setPlaces, fetchPlaces } = useSearchPlacesByFilter({
+    map,
+    selectedFilter,
+    stationLocation,
+    onCleanUp: () => placesMarkers.cleanUp(),
+  });
+
+  useEffect(() => {
+    if (map && selectedFilter) {
+      fetchPlaces(selectedFilter);
+    }
+  }, [map]);
+
+  useEffect(() => {
+    if (!map || !window.naver) return;
+
+    stationMarker.cleanUp();
+    stationMarker.create({
+      latitude: stationLocation.latitude,
+      longitude: stationLocation.longitude,
+      customMarkerData: {
+        marker: getFinalMarkerElement(),
+        width: 46,
+        height: 46,
+      },
+    });
+
+    return () => {
+      stationMarker.cleanUp();
+    };
+  }, [map, stationLocation, stationMarker]);
+
+  useEffect(() => {
+    if (places.length > 0 && selectedFilter && map) {
+      createPlaceMarkers({ map, places, placesMarkers });
+    }
+  }, [places, selectedFilter, map, placesMarkers]);
 
   const handleFilterClick = (filterId: string) => {
-    if (selectedFilter === filterId) {
+    const newFilter = filterId as PlaceType;
+
+    if (selectedFilter === newFilter) {
       setSelectedFilter(null);
+      setPlaces([]);
+      placesMarkers.cleanUp();
     } else {
-      setSelectedFilter(filterId);
+      setSelectedFilter(newFilter);
+      fetchPlaces(newFilter);
     }
   };
+
+  useEffect(() => {
+    return () => {
+      stationMarker.cleanUp();
+      placesMarkers.cleanUp();
+    };
+  }, [stationMarker, placesMarkers]);
 
   return (
     <>
       {createPortal(
         <>
           <MapHeader
-            title={`${subway}역 둘러보기`}
+            title={`${stationName}역 둘러보기`}
             isLookAround={true}
             onClose={handleMapClose}
           />
           <div className={Style.fullScreenMapContainerStyle}>
-            <NaverMap width="100%" height="100vh" zoom={17} />
+            <NaverMap
+              width="100%"
+              height="100vh"
+              zoom={13}
+              center={{
+                latitude: stationLocation.latitude,
+                longitude: stationLocation.longitude,
+              }}
+            />
           </div>
+
           <AnimationBottomSheet>
             <div>
               <div className={Style.containerStyle}>
-                {filterOptions.map((filter) => {
+                {FILTER_OPTIONS.map((filter) => {
                   const IconComponent = filter.icon;
                   const isSelected = selectedFilter === filter.id;
 

--- a/apps/web/src/components/vote-voting/organism/StationMapExplorer.tsx
+++ b/apps/web/src/components/vote-voting/organism/StationMapExplorer.tsx
@@ -4,7 +4,11 @@ import MapHeader from "@/components/midpoint-result/organisms/MapHeader";
 import { AnimationBottomSheet, Text } from "@repo/ui/components";
 import * as Style from "./StationMapExplorer.css";
 import { useState, useEffect } from "react";
-import { FILTER_OPTIONS, PlaceType } from "@/constants/filter-options";
+import {
+  FILTER_OPTIONS,
+  PlaceFilter,
+  PlaceType,
+} from "@/constants/filter-options";
 import { useNaverMap, useMarker, getFinalMarkerElement } from "@repo/naver-map";
 import { useSearchPlacesByFilter } from "@/hooks/useSearchPlacesByFilter";
 import { createPlaceMarkers } from "@/utils/createPlaceMarkers";
@@ -26,7 +30,7 @@ export const StationMapExplorer = ({
   };
 
   const [selectedFilter, setSelectedFilter] = useState<PlaceType | null>(
-    PlaceType.ACTIVITY
+    PlaceFilter.ACTIVITY
   );
 
   const { map } = useNaverMap();

--- a/apps/web/src/components/vote-voting/templates/VoteVotingLayout.tsx
+++ b/apps/web/src/components/vote-voting/templates/VoteVotingLayout.tsx
@@ -17,6 +17,7 @@ import { FixedBottomWithSpacing } from "@/components/fixed-bottom/FixedBottomWit
 import { useStopWatch } from "@/hooks/useStopWatch";
 import { motion } from "@repo/motion";
 import { Tooltip } from "../atom/Tooltip";
+import { useCandidateStation } from "@/hooks/api/useCandidateStation";
 
 interface Props {
   memberId: string;
@@ -40,6 +41,10 @@ export function VoteVotingLayout({ memberId, onNext }: Props) {
     params?.roomId as string,
     memberId
   );
+
+  const roomId = params?.roomId as string;
+  const { data: stationLocationsData } = useCandidateStation(roomId);
+  console.log("stationLocationsData", stationLocationsData);
 
   const { mutate: vote, isPending } = useVoting({
     onSuccess: () => {
@@ -115,6 +120,7 @@ export function VoteVotingLayout({ memberId, onNext }: Props) {
               view={view}
               list={candidatesData.data}
               selectedCardIds={agreedStationIds.map(({ id }) => id)}
+              stationLocations={stationLocationsData?.data || []}
               onIndexChange={setOrder}
               onSelectCard={({ id, name }) => {
                 const isSelected = agreedStationIds.some(

--- a/apps/web/src/constants/api/index.ts
+++ b/apps/web/src/constants/api/index.ts
@@ -11,8 +11,9 @@ export const API_URLS = {
   GET_ROOM_INFO: "/rooms",
   POST_ROUTE: "/route/",
   POST_ROUTE_COMPLEX: "/route/complex/",
-  GET_RECOMMEND_STATION: "/stations/recommend/",
+  GET_CANDIDATE_STATION: (roomId: string) => `/stations/candidate/${roomId}`,
   POST_JOIN_ROOM: (roomId: string) => `/rooms/${roomId}/join`,
+  POST_SEARCH_PLACES: "/search/places",
 
   // vote
   GET_USER_VOTE_STATUS: (roomId: string) => `/votes/${roomId}/status`,

--- a/apps/web/src/constants/filter-options/index.ts
+++ b/apps/web/src/constants/filter-options/index.ts
@@ -9,17 +9,9 @@ import {
   Shopping,
 } from "../../components/vote-voting/atom/filter-icon";
 
-export type PlaceType =
-  | "ACTIVITY"
-  | "RESTAURANT"
-  | "CAFE"
-  | "BAR"
-  | "NATURE"
-  | "EXHIBITION"
-  | "EVENT"
-  | "SHOPPING";
+export type PlaceType = keyof typeof PlaceFilter;
 
-export const PlaceType = {
+export const PlaceFilter = {
   ACTIVITY: "ACTIVITY" as const,
   RESTAURANT: "RESTAURANT" as const,
   CAFE: "CAFE" as const,
@@ -32,51 +24,51 @@ export const PlaceType = {
 
 export const FILTER_OPTIONS = [
   {
-    id: PlaceType.ACTIVITY,
+    id: PlaceFilter.ACTIVITY,
     name: "액티비티",
     icon: Activity,
-    apiValue: PlaceType.ACTIVITY,
+    apiValue: PlaceFilter.ACTIVITY,
   },
   {
-    id: PlaceType.RESTAURANT,
+    id: PlaceFilter.RESTAURANT,
     name: "식당",
     icon: Restaurant,
-    apiValue: PlaceType.RESTAURANT,
+    apiValue: PlaceFilter.RESTAURANT,
   },
   {
-    id: PlaceType.CAFE,
+    id: PlaceFilter.CAFE,
     name: "카페",
     icon: Cafe,
-    apiValue: PlaceType.CAFE,
+    apiValue: PlaceFilter.CAFE,
   },
   {
-    id: PlaceType.BAR,
+    id: PlaceFilter.BAR,
     name: "술집",
     icon: Bar,
-    apiValue: PlaceType.BAR,
+    apiValue: PlaceFilter.BAR,
   },
   {
-    id: PlaceType.NATURE,
+    id: PlaceFilter.NATURE,
     name: "자연",
     icon: Nature,
-    apiValue: PlaceType.NATURE,
+    apiValue: PlaceFilter.NATURE,
   },
   {
-    id: PlaceType.EXHIBITION,
+    id: PlaceFilter.EXHIBITION,
     name: "전시",
     icon: Exhibition,
-    apiValue: PlaceType.EXHIBITION,
+    apiValue: PlaceFilter.EXHIBITION,
   },
   {
-    id: PlaceType.EVENT,
+    id: PlaceFilter.EVENT,
     name: "이벤트",
     icon: Event,
-    apiValue: PlaceType.EVENT,
+    apiValue: PlaceFilter.EVENT,
   },
   {
-    id: PlaceType.SHOPPING,
+    id: PlaceFilter.SHOPPING,
     name: "쇼핑",
     icon: Shopping,
-    apiValue: PlaceType.SHOPPING,
+    apiValue: PlaceFilter.SHOPPING,
   },
 ];

--- a/apps/web/src/constants/filter-options/index.ts
+++ b/apps/web/src/constants/filter-options/index.ts
@@ -9,16 +9,26 @@ import {
   Shopping,
 } from "../../components/vote-voting/atom/filter-icon";
 
-export enum PlaceType {
-  ACTIVITY = "ACTIVITY",
-  RESTAURANT = "RESTAURANT",
-  CAFE = "CAFE",
-  BAR = "BAR",
-  NATURE = "NATURE",
-  EXHIBITION = "EXHIBITION",
-  EVENT = "EVENT",
-  SHOPPING = "SHOPPING",
-}
+export type PlaceType =
+  | "ACTIVITY"
+  | "RESTAURANT"
+  | "CAFE"
+  | "BAR"
+  | "NATURE"
+  | "EXHIBITION"
+  | "EVENT"
+  | "SHOPPING";
+
+export const PlaceType = {
+  ACTIVITY: "ACTIVITY" as const,
+  RESTAURANT: "RESTAURANT" as const,
+  CAFE: "CAFE" as const,
+  BAR: "BAR" as const,
+  NATURE: "NATURE" as const,
+  EXHIBITION: "EXHIBITION" as const,
+  EVENT: "EVENT" as const,
+  SHOPPING: "SHOPPING" as const,
+} as const;
 
 export const FILTER_OPTIONS = [
   {

--- a/apps/web/src/hooks/api/useCandidateStation.ts
+++ b/apps/web/src/hooks/api/useCandidateStation.ts
@@ -11,7 +11,7 @@ interface Station {
   priority: number;
 }
 
-export interface RecommendStationResponse {
+export interface CandidateStationResponse {
   code: number;
   message: string;
   data: Array<{
@@ -20,14 +20,14 @@ export interface RecommendStationResponse {
   }>;
 }
 
-export type RecommendStationData = Array<{
+export type CandidateStationData = Array<{
   routes: string[];
   station: Station;
 }>;
 
-const fetchRecommendStation = async (roomId: string) => {
+const fetchCandidateStation = async (roomId: string) => {
   const response = await fetch(
-    `${BASE_URL}${API_URLS.GET_RECOMMEND_STATION}${roomId}`,
+    `${BASE_URL}${API_URLS.GET_CANDIDATE_STATION(roomId)}`,
     {
       method: "GET",
       headers: {
@@ -40,13 +40,14 @@ const fetchRecommendStation = async (roomId: string) => {
     throw new Error("Network response was not ok");
   }
 
-  return response.json();
+  return response.json() as Promise<CandidateStationResponse>;
 };
 
-export const useRecommendStation = (roomId: string) => {
-  return useQuery<RecommendStationResponse>({
-    queryKey: ["recommendStation", roomId],
-    queryFn: () => fetchRecommendStation(roomId),
-    // staleTime: 1000 * 60 * 60, // 1시간 동안 신선하게 유지
+export const useCandidateStation = (roomId: string) => {
+  return useQuery<CandidateStationResponse>({
+    queryKey: ["candidateStation", roomId],
+    queryFn: () => fetchCandidateStation(roomId),
+    staleTime: Infinity,
+    gcTime: Infinity,
   });
 };

--- a/apps/web/src/hooks/api/useSearchPlaces.ts
+++ b/apps/web/src/hooks/api/useSearchPlaces.ts
@@ -1,0 +1,85 @@
+import { API_URLS } from "@/constants/api";
+import { PlaceType } from "@/constants/filter-options";
+import { useMutation, useQuery } from "@repo/shared/tanstack-query";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+
+export interface Location {
+  latitude: number;
+  longitude: number;
+}
+
+export interface PlaceResponse {
+  displayName: string;
+  formattedAddress: string;
+  location: Location;
+}
+
+interface PlacesApiResponse {
+  code: number;
+  message: string;
+  data: {
+    placeResponses: PlaceResponse[];
+  };
+}
+
+interface SearchPlacesParams {
+  placeType: PlaceType;
+  latitude: number;
+  longitude: number;
+  maxCount?: number;
+}
+
+// 장소 검색 API 호출 함수
+const searchPlaces = async (
+  params: SearchPlacesParams
+): Promise<PlaceResponse[]> => {
+  const response = await fetch(`${BASE_URL}${API_URLS.POST_SEARCH_PLACES}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json;charset=UTF-8",
+    },
+    body: JSON.stringify({
+      placeType: params.placeType,
+      latitude: params.latitude,
+      longitude: params.longitude,
+      maxCount: params.maxCount || 3,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`API 요청 실패: ${response.status}`);
+  }
+
+  const data: PlacesApiResponse = await response.json();
+
+  if (data.code !== 200) {
+    throw new Error(`API 오류: ${data.message}`);
+  }
+
+  return data.data.placeResponses;
+};
+
+export const usePlaces = () => {
+  return useMutation({
+    mutationFn: searchPlaces,
+  });
+};
+
+export const usePlacesQuery = (params: SearchPlacesParams, options?: any) => {
+  const queryKey = [
+    "places",
+    params.placeType,
+    params.latitude,
+    params.longitude,
+    params.maxCount,
+  ];
+
+  return useQuery({
+    queryKey,
+    queryFn: () => searchPlaces(params),
+    staleTime: Infinity,
+    cacheTime: Infinity,
+    ...options,
+  });
+};

--- a/apps/web/src/hooks/useSearchPlacesByFilter.ts
+++ b/apps/web/src/hooks/useSearchPlacesByFilter.ts
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { usePlaces, PlaceResponse } from "@/hooks/api/useSearchPlaces";
+import { PlaceType } from "@/constants/filter-options";
+import { usePlacesQuery } from "@/hooks/api/useSearchPlaces";
+
+interface SearchPlacesOptions {
+  map: naver.maps.Map | null | undefined;
+  selectedFilter: PlaceType | null;
+  stationLocation: { latitude: number; longitude: number };
+  onCleanUp: () => void;
+}
+export function useSearchPlacesByFilter({
+  map,
+  selectedFilter,
+  stationLocation,
+  onCleanUp,
+}: SearchPlacesOptions) {
+  const [places, setPlaces] = useState<PlaceResponse[]>([]);
+
+  const placesQuery = selectedFilter
+    ? usePlacesQuery(
+        {
+          placeType: selectedFilter,
+          latitude: stationLocation.latitude,
+          longitude: stationLocation.longitude,
+          maxCount: 20,
+        },
+        {
+          enabled: !!map && !!selectedFilter,
+          onSuccess: (data: PlaceResponse[]) => {
+            setPlaces(data);
+          },
+          onError: (error: unknown) => {
+            console.error("장소 검색 중 오류 발생:", error);
+            setPlaces([]);
+            onCleanUp();
+          },
+        }
+      )
+    : null;
+
+  const { mutate: searchPlaces } = usePlaces();
+
+  const fetchPlaces = (filterType: PlaceType) => {
+    if (!map) return;
+
+    searchPlaces(
+      {
+        placeType: filterType,
+        latitude: stationLocation.latitude,
+        longitude: stationLocation.longitude,
+        maxCount: 20,
+      },
+      {
+        onSuccess: (data) => {
+          setPlaces(data);
+        },
+        onError: (error) => {
+          console.error("장소 검색 중 오류 발생:", error);
+          setPlaces([]);
+          onCleanUp();
+        },
+      }
+    );
+  };
+
+  return {
+    places,
+    setPlaces,
+    fetchPlaces,
+    isLoading: placesQuery?.isLoading || false,
+    isError: placesQuery?.isError || false,
+  };
+}

--- a/apps/web/src/utils/createNameElement.ts
+++ b/apps/web/src/utils/createNameElement.ts
@@ -1,0 +1,28 @@
+export interface NameElementOptions {
+  displayName: string;
+  isVisible?: boolean;
+}
+
+export function createNameElement({
+  displayName,
+  isVisible = false,
+}: NameElementOptions): HTMLDivElement {
+  const nameElement = document.createElement("div");
+  nameElement.textContent = displayName;
+  nameElement.style.position = "absolute";
+  nameElement.style.top = "100%";
+  nameElement.style.left = "50%";
+  nameElement.style.transform = "translateX(-50%)";
+  nameElement.style.color = "#1D1D1D";
+  nameElement.style.webkitTextStrokeWidth = "0.1px";
+  nameElement.style.webkitTextStrokeColor = "#FFF";
+  nameElement.style.fontFamily = "Pretendard";
+  nameElement.style.fontSize = "16px";
+  nameElement.style.fontStyle = "normal";
+  nameElement.style.fontWeight = "700";
+  nameElement.style.lineHeight = "24px";
+  nameElement.style.whiteSpace = "nowrap";
+  nameElement.style.display = isVisible ? "block" : "none";
+
+  return nameElement;
+}

--- a/apps/web/src/utils/createPlaceMarkers.ts
+++ b/apps/web/src/utils/createPlaceMarkers.ts
@@ -1,0 +1,90 @@
+import { DotMarker, getFinalMarkerElement } from "@repo/naver-map";
+import { theme } from "@repo/ui/tokens";
+import { createNameElement } from "@/utils/createNameElement";
+import { PlaceResponse } from "@/hooks/api/useSearchPlaces";
+
+interface MarkerController {
+  create: (params: {
+    latitude: number;
+    longitude: number;
+    customMarkerData?: {
+      marker: HTMLDivElement;
+      width?: number;
+      height?: number;
+    };
+  }) => naver.maps.Marker | undefined;
+  cleanUp: () => void;
+}
+
+export const createDotMarker = () =>
+  DotMarker({
+    size: 7,
+    color: theme.colors.orange5,
+    borderColor: theme.colors.orange50,
+  });
+
+export interface CreatePlaceMarkerOptions {
+  map: naver.maps.Map | null;
+  places: PlaceResponse[];
+  placesMarkers: MarkerController;
+}
+
+export const createPlaceMarkers = ({
+  map,
+  places,
+  placesMarkers,
+}: CreatePlaceMarkerOptions) => {
+  if (!map || !window.naver) return;
+
+  placesMarkers.cleanUp();
+
+  places.forEach((place) => {
+    const markerWrapper = document.createElement("div");
+    markerWrapper.style.position = "relative";
+    markerWrapper.style.pointerEvents = "auto";
+
+    let isFinal = false;
+    const dotMarkerElement = createDotMarker();
+    const nameElement = createNameElement({ displayName: place.displayName });
+
+    markerWrapper.appendChild(
+      dotMarkerElement || document.createElement("div")
+    );
+    markerWrapper.appendChild(nameElement);
+
+    const marker = placesMarkers.create({
+      latitude: place.location.latitude,
+      longitude: place.location.longitude,
+      customMarkerData: {
+        marker: markerWrapper,
+        width: 30,
+        height: 30,
+      },
+    });
+
+    if (marker && window.naver) {
+      naver.maps.Event.addListener(marker, "click", () => {
+        if (!isFinal) {
+          const finalEl = getFinalMarkerElement();
+          finalEl.style.position = "absolute";
+          finalEl.style.top = "50%";
+          finalEl.style.left = "50%";
+          finalEl.style.transform = "translate(-50%, -100%)";
+          finalEl.style.pointerEvents = "auto";
+
+          markerWrapper.replaceChildren(finalEl, nameElement);
+          isFinal = true;
+        } else {
+          markerWrapper.replaceChildren(
+            createDotMarker() || document.createElement("div"),
+            nameElement
+          );
+          isFinal = false;
+        }
+
+        nameElement.style.display =
+          nameElement.style.display === "none" ? "block" : "none";
+      });
+    }
+  });
+};

--- a/apps/web/src/utils/createPlaceMarkers.ts
+++ b/apps/web/src/utils/createPlaceMarkers.ts
@@ -46,7 +46,9 @@ export const createPlaceMarkers = ({
     let isFinal = false;
     const dotMarkerElement = createDotMarker();
     const nameElement = createNameElement({ displayName: place.displayName });
-
+    if (dotMarkerElement) {
+      dotMarkerElement.style.zIndex = "1";
+    }
     markerWrapper.appendChild(
       dotMarkerElement || document.createElement("div")
     );

--- a/packages/naver-map/src/NaverMap.tsx
+++ b/packages/naver-map/src/NaverMap.tsx
@@ -29,6 +29,7 @@ export const NaverMap = ({
   const mapRef = useRef<HTMLDivElement>(null);
   const [mapInstance, setMapInstance] = useState<NaverMapInstance | null>(null);
   const [isLoaded, setIsLoaded] = useState(false);
+  const [hasSetInitialCenter, setHasSetInitialCenter] = useState(false);
   const { setMap } = useNaverMap();
 
   const loadNaverMapScript = () => {
@@ -95,14 +96,15 @@ export const NaverMap = ({
   }, [isLoaded]);
 
   useEffect(() => {
-    if (mapInstance && center) {
+    if (mapInstance && center && !hasSetInitialCenter) {
       const centerPosition = new window.naver.maps.LatLng(
         center.latitude,
         center.longitude
       );
       mapInstance.setCenter(centerPosition);
+      setHasSetInitialCenter(true);
     }
-  }, [mapInstance, center]);
+  }, [mapInstance, center, hasSetInitialCenter]);
 
   return (
     <Flex style={{ maxWidth: "600px" }}>

--- a/packages/naver-map/src/overlays/marker/final-marker/FinalMarker.tsx
+++ b/packages/naver-map/src/overlays/marker/final-marker/FinalMarker.tsx
@@ -29,6 +29,8 @@ export const getFinalMarkerElement = () => {
       }
     </style>
   `;
+  element.style.zIndex = "2";
+  element.style.position = "relative";
   return element;
 };
 


### PR DESCRIPTION

## 🤔 문제 및 해결방안

- 기존 투표 후보지 조회에서는 역 위치의 좌표 정보를 제공하지 않아, 새로운 /stations/candidate/{roomId} API를 연동하여 역 위치의 정확한 좌표를 포함하도록 구현했습니다.

## ✍️ 구현 설명

- useCandidateStation 훅을 새롭게 생성하여 후보 역 데이터를 조회합니다.
- useSearchPlacesByFilter 훅을 통해 역 주변 장소를 필터링하여 검색할 수 있도록 구현했습니다.
- 둘러보기 마커 생성 로직을 createPlaceMarkers 유틸리티 함수로 분리하였습니다. 

### 📷 이미지 첨부 (Option)

https://github.com/user-attachments/assets/aa5765d1-2e27-4114-b483-7a84ef0faf94



### ⚠️ 유의할 점! (Option)
- 

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
