### PR TITLE
fix: 둘러보기 MapHeader 미표기, 마커 상태 유지 버그 수정

### DIFF
--- a/apps/web/src/components/midpoint-result/molecules/styles.css.ts
+++ b/apps/web/src/components/midpoint-result/molecules/styles.css.ts
@@ -28,7 +28,7 @@ export const headerStyle = style({
   width: "100%",
   maxWidth: "600px",
   height: "58px",
-  zIndex: zIndex.floating,
+  zIndex: zIndex.toast,
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
@@ -71,7 +71,7 @@ export const transportContainerStyle = style({
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
-  zIndex: zIndex.toast,
+  zIndex: zIndex.overlay,
 });
 
 export const progressBarStyle = style({

--- a/apps/web/src/components/vote-voting/organism/StationMapExplorer.tsx
+++ b/apps/web/src/components/vote-voting/organism/StationMapExplorer.tsx
@@ -9,7 +9,7 @@ import {
   PlaceFilter,
   PlaceType,
 } from "@/constants/filter-options";
-import { useNaverMap, useMarker, getFinalMarkerElement } from "@repo/naver-map";
+import { useNaverMap, useMarker } from "@repo/naver-map";
 import { useSearchPlacesByFilter } from "@/hooks/useSearchPlacesByFilter";
 import { createPlaceMarkers } from "@/utils/createPlaceMarkers";
 
@@ -33,6 +33,8 @@ export const StationMapExplorer = ({
     PlaceFilter.ACTIVITY
   );
 
+  const [activeMarkerId, setActiveMarkerId] = useState<string | null>(null);
+
   const { map } = useNaverMap();
   const stationMarker = useMarker({ map: map! });
   const placesMarkers = useMarker({ map: map! });
@@ -53,17 +55,6 @@ export const StationMapExplorer = ({
   useEffect(() => {
     if (!map || !window.naver) return;
 
-    stationMarker.cleanUp();
-    stationMarker.create({
-      latitude: stationLocation.latitude,
-      longitude: stationLocation.longitude,
-      customMarkerData: {
-        marker: getFinalMarkerElement(),
-        width: 46,
-        height: 46,
-      },
-    });
-
     return () => {
       stationMarker.cleanUp();
     };
@@ -71,21 +62,24 @@ export const StationMapExplorer = ({
 
   useEffect(() => {
     if (places.length > 0 && selectedFilter && map) {
-      createPlaceMarkers({ map, places, placesMarkers });
+      createPlaceMarkers({
+        map,
+        places,
+        placesMarkers,
+        activeMarkerId,
+        onMarkerClick: setActiveMarkerId,
+      });
     }
-  }, [places, selectedFilter, map, placesMarkers]);
+  }, [places, selectedFilter, map, placesMarkers, activeMarkerId]);
 
   const handleFilterClick = (filterId: string) => {
     const newFilter = filterId as PlaceType;
-
     if (selectedFilter === newFilter) {
-      setSelectedFilter(null);
-      setPlaces([]);
-      placesMarkers.cleanUp();
-    } else {
-      setSelectedFilter(newFilter);
-      fetchPlaces(newFilter);
+      return;
     }
+    setActiveMarkerId(null);
+    setSelectedFilter(newFilter);
+    fetchPlaces(newFilter);
   };
 
   useEffect(() => {

--- a/apps/web/src/hooks/api/useSearchPlaces.ts
+++ b/apps/web/src/hooks/api/useSearchPlaces.ts
@@ -13,6 +13,7 @@ export interface PlaceResponse {
   displayName: string;
   formattedAddress: string;
   location: Location;
+  id: string;
 }
 
 interface PlacesApiResponse {

--- a/apps/web/src/hooks/useSearchPlacesByFilter.ts
+++ b/apps/web/src/hooks/useSearchPlacesByFilter.ts
@@ -17,27 +17,25 @@ export function useSearchPlacesByFilter({
 }: SearchPlacesOptions) {
   const [places, setPlaces] = useState<PlaceResponse[]>([]);
 
-  const placesQuery = selectedFilter
-    ? usePlacesQuery(
-        {
-          placeType: selectedFilter,
-          latitude: stationLocation.latitude,
-          longitude: stationLocation.longitude,
-          maxCount: 20,
-        },
-        {
-          enabled: !!map && !!selectedFilter,
-          onSuccess: (data: PlaceResponse[]) => {
-            setPlaces(data);
-          },
-          onError: (error: unknown) => {
-            console.error("장소 검색 중 오류 발생:", error);
-            setPlaces([]);
-            onCleanUp();
-          },
-        }
-      )
-    : null;
+  const placesQuery = usePlacesQuery(
+    {
+      placeType: selectedFilter || "ACTIVITY",
+      latitude: stationLocation.latitude,
+      longitude: stationLocation.longitude,
+      maxCount: 20,
+    },
+    {
+      enabled: !!map && !!selectedFilter,
+      onSuccess: (data: PlaceResponse[]) => {
+        setPlaces(data);
+      },
+      onError: (error: unknown) => {
+        console.error("장소 검색 중 오류 발생:", error);
+        setPlaces([]);
+        onCleanUp();
+      },
+    }
+  );
 
   const { mutate: searchPlaces } = usePlaces();
 

--- a/apps/web/src/utils/createPlaceMarkers.ts
+++ b/apps/web/src/utils/createPlaceMarkers.ts
@@ -27,31 +27,52 @@ export interface CreatePlaceMarkerOptions {
   map: naver.maps.Map | null;
   places: PlaceResponse[];
   placesMarkers: MarkerController;
+  activeMarkerId: string | null;
+  onMarkerClick?: (id: string | null) => void;
 }
 
 export const createPlaceMarkers = ({
   map,
   places,
   placesMarkers,
+  activeMarkerId,
+  onMarkerClick,
 }: CreatePlaceMarkerOptions) => {
   if (!map || !window.naver) return;
 
   placesMarkers.cleanUp();
 
   places.forEach((place) => {
+    const markerId =
+      place.id || `${place.location.latitude},${place.location.longitude}`;
     const markerWrapper = document.createElement("div");
     markerWrapper.style.position = "relative";
     markerWrapper.style.pointerEvents = "auto";
 
-    let isFinal = false;
-    const dotMarkerElement = createDotMarker();
     const nameElement = createNameElement({ displayName: place.displayName });
-    if (dotMarkerElement) {
-      dotMarkerElement.style.zIndex = "1";
+    const isActive = markerId === activeMarkerId;
+
+    if (isActive) {
+      const finalEl: HTMLDivElement = getFinalMarkerElement();
+      finalEl.style.position = "absolute";
+      finalEl.style.top = "50%";
+      finalEl.style.left = "50%";
+      finalEl.style.transform = "translate(-50%, -100%)";
+      finalEl.style.pointerEvents = "auto";
+
+      markerWrapper.appendChild(finalEl);
+      nameElement.style.display = "block";
+    } else {
+      const dotMarkerElement = createDotMarker();
+      if (dotMarkerElement) {
+        dotMarkerElement.style.zIndex = "1";
+      }
+      markerWrapper.appendChild(
+        dotMarkerElement || document.createElement("div")
+      );
+      nameElement.style.display = "none";
     }
-    markerWrapper.appendChild(
-      dotMarkerElement || document.createElement("div")
-    );
+
     markerWrapper.appendChild(nameElement);
 
     const marker = placesMarkers.create({
@@ -64,28 +85,13 @@ export const createPlaceMarkers = ({
       },
     });
 
-    if (marker && window.naver) {
+    if (marker) {
       naver.maps.Event.addListener(marker, "click", () => {
-        if (!isFinal) {
-          const finalEl = getFinalMarkerElement();
-          finalEl.style.position = "absolute";
-          finalEl.style.top = "50%";
-          finalEl.style.left = "50%";
-          finalEl.style.transform = "translate(-50%, -100%)";
-          finalEl.style.pointerEvents = "auto";
-
-          markerWrapper.replaceChildren(finalEl, nameElement);
-          isFinal = true;
+        if (isActive) {
+          onMarkerClick?.(null);
         } else {
-          markerWrapper.replaceChildren(
-            createDotMarker() || document.createElement("div"),
-            nameElement
-          );
-          isFinal = false;
+          onMarkerClick?.(markerId);
         }
-
-        nameElement.style.display =
-          nameElement.style.display === "none" ? "block" : "none";
       });
     }
   });


### PR DESCRIPTION
## 🤔 문제 및 해결방안

- 둘러보기에서 Mapheader가 안보이는 문제 발생
- 작업 중에 기존에 장소 마커를 클릭했을 때, 지도 이동 시에 마커가 클릭된 상태로 유지되지 않고 새롭게 렌더링되는 문제 발생

## ✍️ 구현 설명

- 레이어 우선순위 문제로 headerStyle의 zIndex 값을 증가시켜 MapHeader가 상위 계층에 렌더링되도록 수정했습니다.
- usePlacesQuery Hook의 조건부 호출로 발생한 오류를 enabled 분기 처리로 해결했습니다.
- activeMarkerId 상태를 추가하여 선택된 마커의 ID를 관리하고, 지도 이동 시 클릭된 마커 상태가 유지되도록 개선했습니다.
- 둘러보기 역 관련 코드 제거했습니다.

### 📷 이미지 첨부 (Option)

https://github.com/user-attachments/assets/45e892dd-4d71-4465-9e2d-cb24fc4cf6fd


### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
