### PR TITLE
fix: 필터 바텀 시트 UI 수정

### DIFF
--- a/apps/web/src/components/vote-voting/organism/StationMapExplorer.css.ts
+++ b/apps/web/src/components/vote-voting/organism/StationMapExplorer.css.ts
@@ -17,6 +17,7 @@ export const fullScreenMapContainerStyle = style({
 export const containerStyle = style({
   width: "100%",
   display: "flex",
+  justifyContent: "space-between",
   overflowX: "auto",
   scrollbarWidth: "none",
   WebkitOverflowScrolling: "touch",


### PR DESCRIPTION
## 🤔 문제 및 해결방안

- 바텀 시트의 필터 카테고리 UI가 왼쪽으로 치우쳐져 있었습니다. 

## ✍️ 구현 설명

- justifyContent: "space-between" CSS 코드 추가했습니다.

### 📷 이미지 첨부 (Option)

<img width="599" alt="스크린샷 2025-04-17 오후 10 04 36" src="https://github.com/user-attachments/assets/6ded163d-1807-4f43-9a2b-5fd352622a2e" />


### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
