### PR TITLE
fix: CardItem 클릭 영역 버그 해결

### DIFF
--- a/apps/web/src/components/vote-voting/atom/Tooltip.tsx
+++ b/apps/web/src/components/vote-voting/atom/Tooltip.tsx
@@ -51,13 +51,14 @@ export const Tooltip = ({ view }: { view: "card" | "list" }) => {
         >
           역을 누르고 주변을 둘러보세요!
         </Text>
-        <Flex onClick={handleClose}>
+        <Flex onClick={handleClose} style={{ cursor: "pointer" }}>
           <XIcon />
         </Flex>
         <div
           style={{
             position: "absolute",
             top: 23,
+            cursor: "pointer",
           }}
         >
           <Triangle />

--- a/apps/web/src/components/vote-voting/organism/CardItem.css.ts
+++ b/apps/web/src/components/vote-voting/organism/CardItem.css.ts
@@ -15,6 +15,7 @@ export const containerStyle = style({
 export const cardContainerStyle = style({
   backgroundColor: "#fff",
   borderRadius: 20,
+  cursor: "pointer",
 });
 
 export const topContainerStyle = style({

--- a/apps/web/src/components/vote-voting/organism/CardItem.tsx
+++ b/apps/web/src/components/vote-voting/organism/CardItem.tsx
@@ -7,8 +7,6 @@ import { theme } from "@repo/ui/tokens";
 import { SUBWAY_META } from "@/constants/subway";
 import { useState } from "react";
 import { StationMapExplorer } from "./StationMapExplorer";
-import { useCandidateStation } from "@/hooks/api/useCandidateStation";
-import { useParams } from "next/navigation";
 import { CandidateStationData } from "@/hooks/api/useCandidateStation";
 
 interface Props extends Candidate {
@@ -59,10 +57,7 @@ export function CardItem({
 
   return (
     <Flex direction="column" gap={8} className={stationName}>
-      <div
-        className={classMerge(className, Style.containerStyle)}
-        onClick={handleMapOpen}
-      >
+      <div className={classMerge(className, Style.containerStyle)}>
         <motion.div
           initial={view}
           variants={{
@@ -79,6 +74,7 @@ export function CardItem({
           }}
           animate={view}
           className={Style.cardContainerStyle}
+          onClick={handleMapOpen}
         >
           <motion.div
             initial={view}


### PR DESCRIPTION
## 🤔 문제 및 해결방안

- 카드 컴포넌트 외 영역을 눌러도 둘러보기 지도가 활성화 되는 버그 발생

## ✍️ 구현 설명

- containerStyle 이 적용된 곳에 onClick을 적용하였던게 원인이라 내부 태그에서 onClick을 적용하였습니다.

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

- 추가적으로 불필요한 import 제거

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
